### PR TITLE
Add data pt eevee light to include panels

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -1,0 +1,13 @@
+# https://black.readthedocs.io/en/stable/integrations/github_actions.html
+
+name: Black Lint
+
+on: [push, pull_request]
+
+jobs:
+  black-lint:
+    permissions: {} # Remove all permissions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@23.12.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+/.vscode

--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,674 @@
-Copyright (c) 2024 Max Bebök
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                            Preamble
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ It for now performs on par with the EEVEE-nodes-based rendering present in Fast6
 It also offers increased accuracy, with for example blender cycles emulation which is not possible with EEVEE.
 
 It is currently in development but very usable already!
+
+## Development
+
+### Formatting
+
+This repo uses [the same formatting policy as fast64, using black version 23](https://github.com/Fast-64/fast64/blob/main/README.md#formatting).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# f64render
+
+f64render is an addon adding a Render Engine for [Fast64](https://github.com/Fast-64/fast64)'s F3D materials.
+
+It for now performs on par with the EEVEE-nodes-based rendering present in Fast64, but without the stutters due to EEVEE shaders compilation.
+
+It also offers increased accuracy, with for example blender cycles emulation which is not possible with EEVEE.
+
+It is currently in development but very usable already!

--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ bl_info = {
     "name" : "F64renderer",
     "author" : "Max Bebök",
     "description" : "",
-    "blender" : (4, 2, 0),
+    "blender" : (3, 2, 0),
     "version" : (0, 0, 1),
     "location" : "",
     "warning" : "",

--- a/__init__.py
+++ b/__init__.py
@@ -12,21 +12,23 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 bl_info = {
-    "name" : "f64render",
-    "author" : "Max Bebök, Fast64 community",
-    "description" : "Render engine for fast64 materials.",
-    "blender" : (3, 2, 0),
-    "version" : (0, 0, 1),
-    "location" : "Render Properties > Render Engine",
-    "category" : "3D View"
+    "name": "f64render",
+    "author": "Max Bebök, Fast64 community",
+    "description": "Render engine for fast64 materials.",
+    "blender": (3, 2, 0),
+    "version": (0, 0, 1),
+    "location": "Render Properties > Render Engine",
+    "category": "3D View",
 }
 
 from . import auto_load
 
 auto_load.init()
 
+
 def register():
     auto_load.register()
+
 
 def unregister():
     auto_load.unregister()

--- a/__init__.py
+++ b/__init__.py
@@ -12,14 +12,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 bl_info = {
-    "name" : "F64renderer",
-    "author" : "Max Bebök",
-    "description" : "",
+    "name" : "f64render",
+    "author" : "Max Bebök, Fast64 community",
+    "description" : "Render engine for fast64 materials.",
     "blender" : (3, 2, 0),
     "version" : (0, 0, 1),
-    "location" : "",
-    "warning" : "",
-    "category" : "Generic"
+    "location" : "Render Properties > Render Engine",
+    "category" : "3D View"
 }
 
 from . import auto_load

--- a/auto_load.py
+++ b/auto_load.py
@@ -18,12 +18,14 @@ blender_version = bpy.app.version
 modules = None
 ordered_classes = None
 
+
 def init():
     global modules
     global ordered_classes
 
     modules = get_all_submodules(Path(__file__).parent)
     ordered_classes = get_ordered_classes_to_register(modules)
+
 
 def register():
     for cls in ordered_classes:
@@ -34,6 +36,7 @@ def register():
             continue
         if hasattr(module, "register"):
             module.register()
+
 
 def unregister():
     for cls in reversed(ordered_classes):
@@ -49,12 +52,15 @@ def unregister():
 # Import modules
 #################################################
 
+
 def get_all_submodules(directory):
     return list(iter_submodules(directory, __package__))
+
 
 def iter_submodules(path, package_name):
     for name in sorted(iter_submodule_names(path)):
         yield importlib.import_module("." + name, package_name)
+
 
 def iter_submodule_names(path, root=""):
     for _, module_name, is_package in pkgutil.iter_modules([str(path)]):
@@ -69,21 +75,25 @@ def iter_submodule_names(path, root=""):
 # Find classes to register
 #################################################
 
+
 def get_ordered_classes_to_register(modules):
     return toposort(get_register_deps_dict(modules))
 
+
 def get_register_deps_dict(modules):
     my_classes = set(iter_my_classes(modules))
-    my_classes_by_idname = {cls.bl_idname : cls for cls in my_classes if hasattr(cls, "bl_idname")}
+    my_classes_by_idname = {cls.bl_idname: cls for cls in my_classes if hasattr(cls, "bl_idname")}
 
     deps_dict = {}
     for cls in my_classes:
         deps_dict[cls] = set(iter_my_register_deps(cls, my_classes, my_classes_by_idname))
     return deps_dict
 
+
 def iter_my_register_deps(cls, my_classes, my_classes_by_idname):
     yield from iter_my_deps_from_annotations(cls, my_classes)
     yield from iter_my_deps_from_parent_id(cls, my_classes_by_idname)
+
 
 def iter_my_deps_from_annotations(cls, my_classes):
     for value in typing.get_type_hints(cls, {}, {}).values():
@@ -91,6 +101,7 @@ def iter_my_deps_from_annotations(cls, my_classes):
         if dependency is not None:
             if dependency in my_classes:
                 yield dependency
+
 
 def get_dependency_from_annotation(value):
     if blender_version >= (2, 93):
@@ -102,6 +113,7 @@ def get_dependency_from_annotation(value):
                 return value[1]["type"]
     return None
 
+
 def iter_my_deps_from_parent_id(cls, my_classes_by_idname):
     if issubclass(cls, bpy.types.Panel):
         parent_idname = getattr(cls, "bl_parent_id", None)
@@ -110,12 +122,14 @@ def iter_my_deps_from_parent_id(cls, my_classes_by_idname):
             if parent_cls is not None:
                 yield parent_cls
 
+
 def iter_my_classes(modules):
     base_types = get_register_base_types()
     for cls in get_classes_in_modules(modules):
         if any(issubclass(cls, base) for base in base_types):
             if not getattr(cls, "is_registered", False):
                 yield cls
+
 
 def get_classes_in_modules(modules):
     classes = set()
@@ -124,23 +138,37 @@ def get_classes_in_modules(modules):
             classes.add(cls)
     return classes
 
+
 def iter_classes_in_module(module):
     for value in module.__dict__.values():
         if inspect.isclass(value):
             yield value
 
+
 def get_register_base_types():
-    return set(getattr(bpy.types, name) for name in [
-        "Panel", "Operator", "PropertyGroup",
-        "AddonPreferences", "Header", "Menu",
-        "Node", "NodeSocket", "NodeTree",
-        "UIList", "RenderEngine",
-        "Gizmo", "GizmoGroup",
-    ])
+    return set(
+        getattr(bpy.types, name)
+        for name in [
+            "Panel",
+            "Operator",
+            "PropertyGroup",
+            "AddonPreferences",
+            "Header",
+            "Menu",
+            "Node",
+            "NodeSocket",
+            "NodeTree",
+            "UIList",
+            "RenderEngine",
+            "Gizmo",
+            "GizmoGroup",
+        ]
+    )
 
 
 # Find order to register to solve dependencies
 #################################################
+
 
 def toposort(deps_dict):
     sorted_list = []
@@ -153,5 +181,5 @@ def toposort(deps_dict):
                 sorted_values.add(value)
             else:
                 unsorted.append(value)
-        deps_dict = {value : deps_dict[value] - sorted_values for value in unsorted}
+        deps_dict = {value: deps_dict[value] - sorted_values for value in unsorted}
     return sorted_list

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,73 +1,18 @@
 schema_version = "1.0.0"
 
-# Example of manifest file for a Blender extension
-# Change the values according to your extension
-id = "f64renderer"
-version = "1.0.0"
-name = "F64renderer"
-tagline = "This is another extension"
-maintainer = "Max Bebök"
-# Supported types: "add-on", "theme"
+id = "f64render"
+version = "0.0.1"
+name = "f64render"
+tagline = "Render engine for fast64 materials"
+maintainer = "Max Bebök, Fast64 community"
 type = "add-on"
 
-# Optional link to documentation, support, source files, etc
-# website = "https://extensions.blender.org/add-ons/my-example-package/"
+website = "https://github.com/Fast-64/f64render"
 
-# Optional list defined by Blender and server, see:
-# https://docs.blender.org/manual/en/dev/advanced/extensions/tags.html
-tags = ["Animation", "Sequencer"]
+tags = ["3D View", "Material", "Render"]
 
 blender_version_min = "4.2.0"
-# # Optional: Blender version that the extension does not support, earlier versions are supported.
-# # This can be omitted and defined later on the extensions platform if an issue is found.
-# blender_version_max = "5.1.0"
 
-# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
-# https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
 license = [
-  "SPDX:GPL-2.0-or-later",
+  "SPDX:GPL-3.0-or-later",
 ]
-# Optional: required by some licenses.
-# copyright = [
-#   "2002-2024 Developer Name",
-#   "1998 Company Name",
-# ]
-
-# Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
-# platforms = ["windows-x64", "macos-arm64", "linux-x64"]
-# Other supported platforms: "windows-arm64", "macos-x64"
-
-# Optional: bundle 3rd party Python modules.
-# https://docs.blender.org/manual/en/dev/advanced/extensions/python_wheels.html
-# wheels = [
-#   "./wheels/hexdump-3.3-py3-none-any.whl",
-#   "./wheels/jsmin-3.0.1-py3-none-any.whl",
-# ]
-
-# Optional: add-ons can list which resources they will require:
-# * files (for access of any filesystem operations)
-# * network (for internet access)
-# * clipboard (to read and/or write the system clipboard)
-# * camera (to capture photos and videos)
-# * microphone (to capture audio)
-#
-# If using network, remember to also check `bpy.app.online_access`
-# https://docs.blender.org/manual/en/dev/advanced/extensions/addons.html#internet-access
-#
-# For each permission it is important to also specify the reason why it is required.
-# Keep this a single short sentence without a period (.) at the end.
-# For longer explanations use the documentation or detail page.
-#
-# [permissions]
-# network = "Need to sync motion-capture data to server"
-# files = "Import/export FBX from/to disk"
-# clipboard = "Copy and paste bone transforms"
-
-# Optional: build settings.
-# https://docs.blender.org/manual/en/dev/advanced/extensions/command_line_arguments.html#command-line-args-extension-build
-# [build]
-# paths_exclude_pattern = [
-#   "__pycache__/",
-#   "/.git/",
-#   "/*.zip",
-# ]

--- a/common.py
+++ b/common.py
@@ -8,16 +8,16 @@ import mathutils
 import gpu
 
 from .material.parser import (
-  parse_f3d_rendermode_preset,
-  quantize_direction,
-  quantize_srgb,
-  quantize_tuple,
-  f64_material_parse,
-  node_material_parse,
-  UNIFORM_BUFFER_STRUCT,
-  F64Material,
-  F64RenderState,
-  F64Light,
+    parse_f3d_rendermode_preset,
+    quantize_direction,
+    quantize_srgb,
+    quantize_tuple,
+    f64_material_parse,
+    node_material_parse,
+    UNIFORM_BUFFER_STRUCT,
+    F64Material,
+    F64RenderState,
+    F64Light,
 )
 from .material.cc import SOLID_CC
 from .material.tile import get_tile_conf
@@ -27,172 +27,210 @@ from .properties import F64RenderSettings
 from .globals import F64_GLOBALS
 
 if typing.TYPE_CHECKING:
-  from .renderer import Fast64RenderEngine
+    from .renderer import Fast64RenderEngine
 
 FALLBACK_MATERIAL = F64Material(state=F64RenderState(cc=SOLID_CC))
 FALLBACK_MATERIAL.state.save_cache()
 
+
 def get_struct_ubo_size(s: struct.Struct):
-  return (s.size + 15) & ~15 # force 16-byte alignment
+    return (s.size + 15) & ~15  # force 16-byte alignment
+
 
 UBO_SIZE = get_struct_ubo_size(UNIFORM_BUFFER_STRUCT)
 
+
 @dataclasses.dataclass
 class ObjRenderInfo:
-  obj: bpy.types.Object
-  mvp_matrix: mathutils.Matrix
-  normal_matrix: mathutils.Matrix
-  render_obj: MeshBuffers
-  mats: list[tuple[int, int, F64Material]] # mat idx, indice count, material
+    obj: bpy.types.Object
+    mvp_matrix: mathutils.Matrix
+    normal_matrix: mathutils.Matrix
+    render_obj: MeshBuffers
+    mats: list[tuple[int, int, F64Material]]  # mat idx, indice count, material
+
 
 def get_scene_render_state(scene: bpy.types.Scene):
-  fast64_rs = scene.fast64.renderSettings
-  f64render_rs: F64RenderSettings = scene.f64render.render_settings
-  state = F64RenderState(
-    lights=[F64Light(direction=(0, 0, 0)) for _x in range(0, 8)],
-    ambient_color=quantize_srgb(fast64_rs.ambientColor, force_alpha=True),
-    light_count=2,
-    prim_color=quantize_srgb(f64render_rs.default_prim_color),
-    prim_lod=(f64render_rs.default_lod_frac, f64render_rs.default_lod_min),
-    env_color=quantize_srgb(f64render_rs.default_env_color),
-    ck=tuple((*quantize_srgb(f64render_rs.default_key_center, False), *f64render_rs.default_key_scale, *f64render_rs.default_key_width)),
-    convert=quantize_tuple(f64render_rs.default_convert, 9.0, -1.0, 1.0),
-    cc=SOLID_CC,
-    tex_confs=([get_tile_conf(getattr(f64render_rs, f"default_tex{i}")) for i in range(0, 8)]),
-  )
-  state.lights[0] = F64Light(quantize_srgb(fast64_rs.light0Color, force_alpha=True), quantize_direction(fast64_rs.light0Direction))
-  state.lights[1] = F64Light(quantize_srgb(fast64_rs.light1Color, force_alpha=True), quantize_direction(fast64_rs.light1Direction))
-  state.set_from_rendermode(parse_f3d_rendermode_preset("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"))
-  state.save_cache()
-  return state
+    fast64_rs = scene.fast64.renderSettings
+    f64render_rs: F64RenderSettings = scene.f64render.render_settings
+    state = F64RenderState(
+        lights=[F64Light(direction=(0, 0, 0)) for _x in range(0, 8)],
+        ambient_color=quantize_srgb(fast64_rs.ambientColor, force_alpha=True),
+        light_count=2,
+        prim_color=quantize_srgb(f64render_rs.default_prim_color),
+        prim_lod=(f64render_rs.default_lod_frac, f64render_rs.default_lod_min),
+        env_color=quantize_srgb(f64render_rs.default_env_color),
+        ck=tuple(
+            (
+                *quantize_srgb(f64render_rs.default_key_center, False),
+                *f64render_rs.default_key_scale,
+                *f64render_rs.default_key_width,
+            )
+        ),
+        convert=quantize_tuple(f64render_rs.default_convert, 9.0, -1.0, 1.0),
+        cc=SOLID_CC,
+        tex_confs=([get_tile_conf(getattr(f64render_rs, f"default_tex{i}")) for i in range(0, 8)]),
+    )
+    state.lights[0] = F64Light(
+        quantize_srgb(fast64_rs.light0Color, force_alpha=True), quantize_direction(fast64_rs.light0Direction)
+    )
+    state.lights[1] = F64Light(
+        quantize_srgb(fast64_rs.light1Color, force_alpha=True), quantize_direction(fast64_rs.light1Direction)
+    )
+    state.set_from_rendermode(parse_f3d_rendermode_preset("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"))
+    state.save_cache()
+    return state
+
 
 def draw_f64_obj(render_engine: "Fast64RenderEngine", render_state: F64RenderState, info: ObjRenderInfo):
-  mvp = info.mvp_matrix 
-  bbox = info.render_obj.bounding_box
+    mvp = info.mvp_matrix
+    bbox = info.render_obj.bounding_box
 
-  # we need to figure out where what the min max range is for all axis, but we need to do this after projection
-  # would've been a neat optimization but it does not work :(
-  min_x = min_y = min_z = float('inf')
-  max_x = max_y = max_z = float('-inf')
+    # we need to figure out where what the min max range is for all axis, but we need to do this after projection
+    # would've been a neat optimization but it does not work :(
+    min_x = min_y = min_z = float("inf")
+    max_x = max_y = max_z = float("-inf")
 
-  for v in bbox:
-    v = mvp @ v
-    x, y, z = v.xyz / v.w
+    for v in bbox:
+        v = mvp @ v
+        x, y, z = v.xyz / v.w
 
-    if x < min_x: min_x = x
-    if x > max_x: max_x = x
-    if y < min_y: min_y = y
-    if y > max_y: max_y = y
-    if z < min_z: min_z = z
-    if z > max_z: max_z = z
+        if x < min_x:
+            min_x = x
+        if x > max_x:
+            max_x = x
+        if y < min_y:
+            min_y = y
+        if y > max_y:
+            max_y = y
+        if z < min_z:
+            min_z = z
+        if z > max_z:
+            max_z = z
 
-  if (max_x < -1 or min_x > 1) or (max_y < -1 or min_y > 1) or (max_z < -1 or min_z > 1):
-    if not info.obj.use_f3d_culling:
-      for _, _, f64mat in info.mats:
+    if (max_x < -1 or min_x > 1) or (max_y < -1 or min_y > 1) or (max_z < -1 or min_z > 1):
+        if not info.obj.use_f3d_culling:
+            for _, _, f64mat in info.mats:
+                render_state.set_values_from_cache(f64mat.state)
+        return
+
+    render_engine.shader.uniform_float("matMVP", info.mvp_matrix)
+    render_engine.shader.uniform_float("matNorm", info.normal_matrix)
+
+    for mat_idx, indices_count, f64mat in info.mats:
         render_state.set_values_from_cache(f64mat.state)
-    return
 
-  render_engine.shader.uniform_float("matMVP", info.mvp_matrix)
-  render_engine.shader.uniform_float("matNorm", info.normal_matrix)
+        gpu.state.face_culling_set(f64mat.cull)
+        if not render_engine.use_atomic_rendering:
+            gpu.state.blend_set(render_state.render_mode.blend)
+            gpu.state.depth_test_set(render_state.render_mode.depth_test)
+            gpu.state.depth_mask_set(render_state.render_mode.depth_write)
 
-  for mat_idx, indices_count, f64mat in info.mats:
-    render_state.set_values_from_cache(f64mat.state)
+        for i in range(8):
+            if render_state.tex_confs[i].buff is not render_engine.last_used_textures.get(i):
+                render_engine.shader.uniform_sampler(f"tex{i}", render_state.tex_confs[i].buff)
+                render_engine.last_used_textures[i] = render_state.tex_confs[i].buff
 
-    gpu.state.face_culling_set(f64mat.cull)
-    if not render_engine.use_atomic_rendering:
-      gpu.state.blend_set(render_state.render_mode.blend)
-      gpu.state.depth_test_set(render_state.render_mode.depth_test)
-      gpu.state.depth_mask_set(render_state.render_mode.depth_write)
+        info.render_obj.ubo_mat_data[mat_idx].update(render_state.cached_values)
+        render_engine.shader.uniform_block("material", info.render_obj.ubo_mat_data[mat_idx])
 
-    for i in range(8):
-      if render_state.tex_confs[i].buff is not render_engine.last_used_textures.get(i): 
-        render_engine.shader.uniform_sampler(f"tex{i}", render_state.tex_confs[i].buff)
-        render_engine.last_used_textures[i] = render_state.tex_confs[i].buff
-
-    info.render_obj.ubo_mat_data[mat_idx].update(render_state.cached_values)                        
-    render_engine.shader.uniform_block("material", info.render_obj.ubo_mat_data[mat_idx])
-
-    if render_engine.draw_range_impl:
-      info.render_obj.batch.draw_range(render_engine.shader, elem_start=info.render_obj.index_offsets[mat_idx] * 3, elem_count=indices_count)
-    else:
-      info.render_obj.batch[mat_idx].draw(render_engine.shader)
-
-def collect_obj_info(render_engine: "Fast64RenderEngine", obj: bpy.types.Object, depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool, set_light_dir = True):
-  if (obj.name in hidden_objs_names or
-      obj.type not in {"MESH", "CURVE", "SURFACE", "FONT"} or
-      obj.data is None or
-      (space_view_3d.local_view and not obj.local_view_get(space_view_3d))
-    ):
-    return
-  mesh_id = f"{obj.name}#{obj.data.name}"
-  if mesh_id in F64_GLOBALS.meshCache: # check for objects that transitioned from non-f3d to f3d materials
-    render_obj = F64_GLOBALS.meshCache[mesh_id]
-  else: # Mesh not cached: parse & convert mesh data, then prepare a GPU batch
-    if obj.mode == 'EDIT':
-      mesh = obj.evaluated_get(depsgraph).to_mesh()
-    else:
-      mesh = obj.evaluated_get(depsgraph).to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
-
-    render_obj = F64_GLOBALS.meshCache[mesh_id] = mesh_to_buffers(mesh)
-    render_obj.mesh_name = obj.data.name
-    render_obj.bounding_box = [mathutils.Vector((*corner, 1)) for corner in obj.bound_box]
-
-    mat_count = max(len(obj.material_slots), 1)
-    vert_buf = create_vert_buf(render_engine.vbo_format,
-      render_obj.vert,
-      render_obj.norm,
-      render_obj.color,
-      render_obj.uv,
-    )
-    if render_engine.draw_range_impl:
-      render_obj.batch = batch_for_shader(vert_buf, render_obj.indices)
-    else: # we need to create batches for each material
-      if not obj.material_slots: # if no material slot, we only have one batch for the whole geo
-        render_obj.batch = [batch_for_shader(vert_buf, render_obj.indices)]
-      else:
-        render_obj.batch = []      
-      for i, slot in enumerate(obj.material_slots):
-        indices = render_obj.indices[render_obj.index_offsets[i]:render_obj.index_offsets[i+1]]
-        if len(indices) == 0: # ignore unused materials
-          render_obj.batch.append(None)
+        if render_engine.draw_range_impl:
+            info.render_obj.batch.draw_range(
+                render_engine.shader, elem_start=info.render_obj.index_offsets[mat_idx] * 3, elem_count=indices_count
+            )
         else:
-          render_obj.batch.append(batch_for_shader(vert_buf, indices))
+            info.render_obj.batch[mat_idx].draw(render_engine.shader)
 
-    render_obj.ubo_mat_data = [None] * mat_count
 
-    for i in range(mat_count):
-      render_obj.ubo_mat_data[i] = gpu.types.GPUUniformBuf(bytes(UBO_SIZE))
+def collect_obj_info(
+    render_engine: "Fast64RenderEngine",
+    obj: bpy.types.Object,
+    depsgraph: bpy.types.Depsgraph,
+    hidden_objs_names: set[str],
+    space_view_3d: bpy.types.SpaceView3D,
+    projection_matrix: mathutils.Matrix,
+    view_matrix: mathutils.Matrix,
+    always_set: bool,
+    set_light_dir=True,
+):
+    if (
+        obj.name in hidden_objs_names
+        or obj.type not in {"MESH", "CURVE", "SURFACE", "FONT"}
+        or obj.data is None
+        or (space_view_3d.local_view and not obj.local_view_get(space_view_3d))
+    ):
+        return
+    mesh_id = f"{obj.name}#{obj.data.name}"
+    if mesh_id in F64_GLOBALS.meshCache:  # check for objects that transitioned from non-f3d to f3d materials
+        render_obj = F64_GLOBALS.meshCache[mesh_id]
+    else:  # Mesh not cached: parse & convert mesh data, then prepare a GPU batch
+        if obj.mode == "EDIT":
+            mesh = obj.evaluated_get(depsgraph).to_mesh()
+        else:
+            mesh = obj.evaluated_get(depsgraph).to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
 
-    obj.to_mesh_clear()
+        render_obj = F64_GLOBALS.meshCache[mesh_id] = mesh_to_buffers(mesh)
+        render_obj.mesh_name = obj.data.name
+        render_obj.bounding_box = [mathutils.Vector((*corner, 1)) for corner in obj.bound_box]
 
-  modelview_matrix = obj.matrix_world
-  mvp_matrix = projection_matrix @ modelview_matrix # could we use numpy?
-  normal_matrix = (view_matrix @ obj.matrix_world).to_3x3().inverted().transposed()
+        mat_count = max(len(obj.material_slots), 1)
+        vert_buf = create_vert_buf(
+            render_engine.vbo_format,
+            render_obj.vert,
+            render_obj.norm,
+            render_obj.color,
+            render_obj.uv,
+        )
+        if render_engine.draw_range_impl:
+            render_obj.batch = batch_for_shader(vert_buf, render_obj.indices)
+        else:  # we need to create batches for each material
+            if not obj.material_slots:  # if no material slot, we only have one batch for the whole geo
+                render_obj.batch = [batch_for_shader(vert_buf, render_obj.indices)]
+            else:
+                render_obj.batch = []
+            for i, slot in enumerate(obj.material_slots):
+                indices = render_obj.indices[render_obj.index_offsets[i] : render_obj.index_offsets[i + 1]]
+                if len(indices) == 0:  # ignore unused materials
+                    render_obj.batch.append(None)
+                else:
+                    render_obj.batch.append(batch_for_shader(vert_buf, indices))
 
-  info = ObjRenderInfo(obj, mvp_matrix, normal_matrix, render_obj, [])
+        render_obj.ubo_mat_data = [None] * mat_count
 
-  if len(obj.material_slots) == 0: # fallback if no material, f3d or otherwise
-    info.mats.append((0, len(render_obj.indices) * 3, FALLBACK_MATERIAL))
-  for i, slot in enumerate(obj.material_slots):
-    indices_count = (render_obj.index_offsets[i+1] - render_obj.index_offsets[i]) * 3
-    if indices_count == 0: # ignore unused materials
-      continue
-    if slot.material is None:
-        continue
+        for i in range(mat_count):
+            render_obj.ubo_mat_data[i] = gpu.types.GPUUniformBuf(bytes(UBO_SIZE))
 
-    if slot.material not in F64_GLOBALS.materials_cache:
-      try:
-        if slot.material.is_f3d:
-            F64_GLOBALS.materials_cache[slot.material] = f64_material_parse(slot.material.f3d_mat, always_set, set_light_dir)
-        else: # fallback
-          F64_GLOBALS.materials_cache[slot.material] = node_material_parse(slot.material)
-      except Exception as e:
-        print(f"Error parsing material \"{slot.material.name}\": {e}")
-        F64_GLOBALS.materials_cache[slot.material] = FALLBACK_MATERIAL
+        obj.to_mesh_clear()
 
-    f64mat = F64_GLOBALS.materials_cache[slot.material]
-    if f64mat.cull == "BOTH":
-      continue
+    modelview_matrix = obj.matrix_world
+    mvp_matrix = projection_matrix @ modelview_matrix  # could we use numpy?
+    normal_matrix = (view_matrix @ obj.matrix_world).to_3x3().inverted().transposed()
 
-    info.mats.append((i, indices_count, f64mat))
-  return info
+    info = ObjRenderInfo(obj, mvp_matrix, normal_matrix, render_obj, [])
+
+    if len(obj.material_slots) == 0:  # fallback if no material, f3d or otherwise
+        info.mats.append((0, len(render_obj.indices) * 3, FALLBACK_MATERIAL))
+    for i, slot in enumerate(obj.material_slots):
+        indices_count = (render_obj.index_offsets[i + 1] - render_obj.index_offsets[i]) * 3
+        if indices_count == 0:  # ignore unused materials
+            continue
+        if slot.material is None:
+            continue
+
+        if slot.material not in F64_GLOBALS.materials_cache:
+            try:
+                if slot.material.is_f3d:
+                    F64_GLOBALS.materials_cache[slot.material] = f64_material_parse(
+                        slot.material.f3d_mat, always_set, set_light_dir
+                    )
+                else:  # fallback
+                    F64_GLOBALS.materials_cache[slot.material] = node_material_parse(slot.material)
+            except Exception as e:
+                print(f'Error parsing material "{slot.material.name}": {e}')
+                F64_GLOBALS.materials_cache[slot.material] = FALLBACK_MATERIAL
+
+        f64mat = F64_GLOBALS.materials_cache[slot.material]
+        if f64mat.cull == "BOTH":
+            continue
+
+        info.mats.append((i, indices_count, f64mat))
+    return info

--- a/common.py
+++ b/common.py
@@ -1,0 +1,198 @@
+import dataclasses
+import struct
+import typing
+import numpy as np
+
+import bpy
+import mathutils
+import gpu
+
+from .material.parser import (
+  parse_f3d_rendermode_preset,
+  quantize_direction,
+  quantize_srgb,
+  quantize_tuple,
+  f64_material_parse,
+  node_material_parse,
+  UNIFORM_BUFFER_STRUCT,
+  F64Material,
+  F64RenderState,
+  F64Light,
+)
+from .material.cc import SOLID_CC
+from .material.tile import get_tile_conf
+from .mesh.mesh import MeshBuffers, mesh_to_buffers
+from .mesh.gpu_batch import batch_for_shader, create_vert_buf
+from .properties import F64RenderSettings
+from .globals import F64_GLOBALS
+
+if typing.TYPE_CHECKING:
+  from .renderer import Fast64RenderEngine
+
+FALLBACK_MATERIAL = F64Material(state=F64RenderState(cc=SOLID_CC))
+FALLBACK_MATERIAL.state.save_cache()
+
+def get_struct_ubo_size(s: struct.Struct):
+  return (s.size + 15) & ~15 # force 16-byte alignment
+
+UBO_SIZE = get_struct_ubo_size(UNIFORM_BUFFER_STRUCT)
+
+@dataclasses.dataclass
+class ObjRenderInfo:
+  obj: bpy.types.Object
+  mvp_matrix: mathutils.Matrix
+  normal_matrix: mathutils.Matrix
+  render_obj: MeshBuffers
+  mats: list[tuple[int, int, F64Material]] # mat idx, indice count, material
+
+def get_scene_render_state(scene: bpy.types.Scene):
+  fast64_rs = scene.fast64.renderSettings
+  f64render_rs: F64RenderSettings = scene.f64render.render_settings
+  state = F64RenderState(
+    lights=[F64Light(direction=(0, 0, 0)) for _x in range(0, 8)],
+    ambient_color=quantize_srgb(fast64_rs.ambientColor, force_alpha=True),
+    light_count=2,
+    prim_color=quantize_srgb(f64render_rs.default_prim_color),
+    prim_lod=(f64render_rs.default_lod_frac, f64render_rs.default_lod_min),
+    env_color=quantize_srgb(f64render_rs.default_env_color),
+    ck=tuple((*quantize_srgb(f64render_rs.default_key_center, False), *f64render_rs.default_key_scale, *f64render_rs.default_key_width)),
+    convert=quantize_tuple(f64render_rs.default_convert, 9.0, -1.0, 1.0),
+    cc=SOLID_CC,
+    tex_confs=([get_tile_conf(getattr(f64render_rs, f"default_tex{i}")) for i in range(0, 8)]),
+  )
+  state.lights[0] = F64Light(quantize_srgb(fast64_rs.light0Color, force_alpha=True), quantize_direction(fast64_rs.light0Direction))
+  state.lights[1] = F64Light(quantize_srgb(fast64_rs.light1Color, force_alpha=True), quantize_direction(fast64_rs.light1Direction))
+  state.set_from_rendermode(parse_f3d_rendermode_preset("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"))
+  state.save_cache()
+  return state
+
+def draw_f64_obj(render_engine: "Fast64RenderEngine", render_state: F64RenderState, info: ObjRenderInfo):
+  mvp = info.mvp_matrix 
+  bbox = info.render_obj.bounding_box
+
+  # we need to figure out where what the min max range is for all axis, but we need to do this after projection
+  # would've been a neat optimization but it does not work :(
+  min_x = min_y = min_z = float('inf')
+  max_x = max_y = max_z = float('-inf')
+
+  for v in bbox:
+    v = mvp @ v
+    x, y, z = v.xyz / v.w
+
+    if x < min_x: min_x = x
+    if x > max_x: max_x = x
+    if y < min_y: min_y = y
+    if y > max_y: max_y = y
+    if z < min_z: min_z = z
+    if z > max_z: max_z = z
+
+  if (max_x < -1 or min_x > 1) or (max_y < -1 or min_y > 1) or (max_z < -1 or min_z > 1):
+    if not info.obj.use_f3d_culling:
+      for _, _, f64mat in info.mats:
+        render_state.set_values_from_cache(f64mat.state)
+    return
+
+  render_engine.shader.uniform_float("matMVP", info.mvp_matrix)
+  render_engine.shader.uniform_float("matNorm", info.normal_matrix)
+
+  for mat_idx, indices_count, f64mat in info.mats:
+    render_state.set_values_from_cache(f64mat.state)
+
+    gpu.state.face_culling_set(f64mat.cull)
+    if not render_engine.use_atomic_rendering:
+      gpu.state.blend_set(render_state.render_mode.blend)
+      gpu.state.depth_test_set(render_state.render_mode.depth_test)
+      gpu.state.depth_mask_set(render_state.render_mode.depth_write)
+
+    for i in range(8):
+      if render_state.tex_confs[i].buff is not render_engine.last_used_textures.get(i): 
+        render_engine.shader.uniform_sampler(f"tex{i}", render_state.tex_confs[i].buff)
+        render_engine.last_used_textures[i] = render_state.tex_confs[i].buff
+
+    info.render_obj.ubo_mat_data[mat_idx].update(render_state.cached_values)                        
+    render_engine.shader.uniform_block("material", info.render_obj.ubo_mat_data[mat_idx])
+
+    if render_engine.draw_range_impl:
+      info.render_obj.batch.draw_range(render_engine.shader, elem_start=info.render_obj.index_offsets[mat_idx] * 3, elem_count=indices_count)
+    else:
+      info.render_obj.batch[mat_idx].draw(render_engine.shader)
+
+def collect_obj_info(render_engine: "Fast64RenderEngine", obj: bpy.types.Object, depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool, set_light_dir = True):
+  if (obj.name in hidden_objs_names or
+      obj.type not in {"MESH", "CURVE", "SURFACE", "FONT"} or
+      obj.data is None or
+      (space_view_3d.local_view and not obj.local_view_get(space_view_3d))
+    ):
+    return
+  mesh_id = f"{obj.name}#{obj.data.name}"
+  if mesh_id in F64_GLOBALS.meshCache: # check for objects that transitioned from non-f3d to f3d materials
+    render_obj = F64_GLOBALS.meshCache[mesh_id]
+  else: # Mesh not cached: parse & convert mesh data, then prepare a GPU batch
+    if obj.mode == 'EDIT':
+      mesh = obj.evaluated_get(depsgraph).to_mesh()
+    else:
+      mesh = obj.evaluated_get(depsgraph).to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
+
+    render_obj = F64_GLOBALS.meshCache[mesh_id] = mesh_to_buffers(mesh)
+    render_obj.mesh_name = obj.data.name
+    render_obj.bounding_box = [mathutils.Vector((*corner, 1)) for corner in obj.bound_box]
+
+    mat_count = max(len(obj.material_slots), 1)
+    vert_buf = create_vert_buf(render_engine.vbo_format,
+      render_obj.vert,
+      render_obj.norm,
+      render_obj.color,
+      render_obj.uv,
+    )
+    if render_engine.draw_range_impl:
+      render_obj.batch = batch_for_shader(vert_buf, render_obj.indices)
+    else: # we need to create batches for each material
+      if not obj.material_slots: # if no material slot, we only have one batch for the whole geo
+        render_obj.batch = [batch_for_shader(vert_buf, render_obj.indices)]
+      else:
+        render_obj.batch = []      
+      for i, slot in enumerate(obj.material_slots):
+        indices = render_obj.indices[render_obj.index_offsets[i]:render_obj.index_offsets[i+1]]
+        if len(indices) == 0: # ignore unused materials
+          render_obj.batch.append(None)
+        else:
+          render_obj.batch.append(batch_for_shader(vert_buf, indices))
+
+    render_obj.ubo_mat_data = [None] * mat_count
+
+    for i in range(mat_count):
+      render_obj.ubo_mat_data[i] = gpu.types.GPUUniformBuf(bytes(UBO_SIZE))
+
+    obj.to_mesh_clear()
+
+  modelview_matrix = obj.matrix_world
+  mvp_matrix = projection_matrix @ modelview_matrix # could we use numpy?
+  normal_matrix = (view_matrix @ obj.matrix_world).to_3x3().inverted().transposed()
+
+  info = ObjRenderInfo(obj, mvp_matrix, normal_matrix, render_obj, [])
+
+  if len(obj.material_slots) == 0: # fallback if no material, f3d or otherwise
+    info.mats.append((0, len(render_obj.indices) * 3, FALLBACK_MATERIAL))
+  for i, slot in enumerate(obj.material_slots):
+    indices_count = (render_obj.index_offsets[i+1] - render_obj.index_offsets[i]) * 3
+    if indices_count == 0: # ignore unused materials
+      continue
+    if slot.material is None:
+        continue
+
+    if slot.material not in F64_GLOBALS.materials_cache:
+      try:
+        if slot.material.is_f3d:
+            F64_GLOBALS.materials_cache[slot.material] = f64_material_parse(slot.material.f3d_mat, always_set, set_light_dir)
+        else: # fallback
+          F64_GLOBALS.materials_cache[slot.material] = node_material_parse(slot.material)
+      except Exception as e:
+        print(f"Error parsing material \"{slot.material.name}\": {e}")
+        F64_GLOBALS.materials_cache[slot.material] = FALLBACK_MATERIAL
+
+    f64mat = F64_GLOBALS.materials_cache[slot.material]
+    if f64mat.cull == "BOTH":
+      continue
+
+    info.mats.append((i, indices_count, f64mat))
+  return info

--- a/globals.py
+++ b/globals.py
@@ -1,19 +1,22 @@
 import bpy
 
-class F64Globals:
-  def __init__(self):
-    self.clear()
-  def clear(self):
-    self.materials_cache: dict[bpy.types.Material, "F64Material"] = {}
-    self.meshCache: dict["MeshBuffers"] = {}
-    self.obj_lights: dict[str, "F64Light"] = {}
-    self.sm64_area_lookup: dict|None = None
-    self.oot_room_lookup: dict|None = None # oot
-    self.rebuid_shaders = True
-    self.current_ucode = self.world_lighting = self.current_gamemode = None
 
-  def clear_areas(self):
-    self.sm64_area_lookup = None
-    self.oot_room_lookup = None
+class F64Globals:
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        self.materials_cache: dict[bpy.types.Material, "F64Material"] = {}
+        self.meshCache: dict["MeshBuffers"] = {}
+        self.obj_lights: dict[str, "F64Light"] = {}
+        self.sm64_area_lookup: dict | None = None
+        self.oot_room_lookup: dict | None = None  # oot
+        self.rebuid_shaders = True
+        self.current_ucode = self.world_lighting = self.current_gamemode = None
+
+    def clear_areas(self):
+        self.sm64_area_lookup = None
+        self.oot_room_lookup = None
+
 
 F64_GLOBALS = F64Globals()

--- a/globals.py
+++ b/globals.py
@@ -11,7 +11,7 @@ class F64Globals:
         self.obj_lights: dict[str, "F64Light"] = {}
         self.sm64_area_lookup: dict | None = None
         self.oot_room_lookup: dict | None = None  # oot
-        self.rebuid_shaders = True
+        self.rebuild_shaders = True
         self.current_ucode = self.world_lighting = self.current_gamemode = None
 
     def clear_areas(self):

--- a/globals.py
+++ b/globals.py
@@ -1,0 +1,19 @@
+import bpy
+
+class F64Globals:
+  def __init__(self):
+    self.clear()
+  def clear(self):
+    self.materials_cache: dict[bpy.types.Material, "F64Material"] = {}
+    self.meshCache: dict["MeshBuffers"] = {}
+    self.obj_lights: dict[str, "F64Light"] = {}
+    self.sm64_area_lookup: dict|None = None
+    self.oot_room_lookup: dict|None = None # oot
+    self.rebuid_shaders = True
+    self.current_ucode = self.world_lighting = self.current_gamemode = None
+
+  def clear_areas(self):
+    self.sm64_area_lookup = None
+    self.oot_room_lookup = None
+
+F64_GLOBALS = F64Globals()

--- a/material/blender.py
+++ b/material/blender.py
@@ -1,6 +1,4 @@
-from dataclasses import dataclass
-
-import numpy as np
+import functools
 
 BL_INP = {
   "G_BL_0"      : 0,
@@ -16,15 +14,6 @@ BL_INP = {
   "G_BL_A_MEM"  : 10,
 }
 
-def get_blender_settings(f3d_mat) -> tuple:
-  rdp = f3d_mat.rdp_settings
-  cycle0 = (rdp.blend_p1, rdp.blend_a1, rdp.blend_m1, rdp.blend_b1)
-  cycle1 = (rdp.blend_p2, rdp.blend_a2, rdp.blend_m2, rdp.blend_b2)
-
-  if f3d_mat.rdp_settings.g_mdsft_cycletype == 'G_CYC_1CYCLE':
-    cycle1 = cycle0
-
-  return (
-    BL_INP[cycle0[0]], BL_INP[cycle0[1]], BL_INP[cycle0[2]], BL_INP[cycle0[3]],
-    BL_INP[cycle1[0]], BL_INP[cycle1[1]], BL_INP[cycle1[2]], BL_INP[cycle1[3]],
-  )
+@functools.cache
+def get_blender_settings(blend_cycle1: tuple[str, str, str, str], blend_cycle2: tuple[str, str, str, str]) -> tuple:
+  return tuple(BL_INP[x] for x in blend_cycle1 + blend_cycle2)

--- a/material/blender.py
+++ b/material/blender.py
@@ -1,19 +1,20 @@
 import functools
 
 BL_INP = {
-  "G_BL_0"      : 0,
-  "G_BL_1"      : 1,
-  "G_BL_CLR_IN" : 2,
-  "G_BL_CLR_MEM": 3,
-  "G_BL_CLR_BL" : 4,
-  "G_BL_CLR_FOG": 5,
-  "G_BL_A_IN"   : 6,
-  "G_BL_A_FOG"  : 7,
-  "G_BL_A_SHADE": 8,
-  "G_BL_1MA"    : 9,
-  "G_BL_A_MEM"  : 10,
+    "G_BL_0": 0,
+    "G_BL_1": 1,
+    "G_BL_CLR_IN": 2,
+    "G_BL_CLR_MEM": 3,
+    "G_BL_CLR_BL": 4,
+    "G_BL_CLR_FOG": 5,
+    "G_BL_A_IN": 6,
+    "G_BL_A_FOG": 7,
+    "G_BL_A_SHADE": 8,
+    "G_BL_1MA": 9,
+    "G_BL_A_MEM": 10,
 }
+
 
 @functools.cache
 def get_blender_settings(blend_cycle1: tuple[str, str, str, str], blend_cycle2: tuple[str, str, str, str]) -> tuple:
-  return tuple(BL_INP[x] for x in blend_cycle1 + blend_cycle2)
+    return tuple(BL_INP[x] for x in blend_cycle1 + blend_cycle2)

--- a/material/cc.py
+++ b/material/cc.py
@@ -77,6 +77,11 @@ CC2_A = { # TEX0 and TEX1 are swapped
   "PRIM_LOD_FRAC": 9,
 }
 
+SOLID_CC=(0, 0, 0, 5, 
+          0, 0, 0, 5,
+          0, 0, 0, 5, 
+          0, 0, 0, 5)
+
 # Fetches CC settings from a given fast64-material
 def get_cc_settings(f3d_mat) -> np.ndarray:
   c0 = f3d_mat.combiner1

--- a/material/cc.py
+++ b/material/cc.py
@@ -4,95 +4,108 @@ import numpy as np
 import bpy
 
 CC1_C = {
-  "0":               0,
-  "1":               1,
-  "COMBINED":        2,
-  "TEXEL0":          3,
-  "TEXEL1":          4,
-  "PRIMITIVE":       5,
-  "SHADE":           6,
-  "ENVIRONMENT":     7,
-  "CENTER":          8,
-  "SCALE":           9,
-  "COMBINED_ALPHA":  10,
-  "TEXEL0_ALPHA":    11,
-  "TEXEL1_ALPHA":    12,
-  "PRIMITIVE_ALPHA": 13,
-  "SHADE_ALPHA":     14,
-  "ENV_ALPHA":       15,
-  "LOD_FRACTION":    16,
-  "PRIM_LOD_FRAC":   17,
-  "NOISE":           18,
-  "K4":              19,
-  "K5":              20,
+    "0": 0,
+    "1": 1,
+    "COMBINED": 2,
+    "TEXEL0": 3,
+    "TEXEL1": 4,
+    "PRIMITIVE": 5,
+    "SHADE": 6,
+    "ENVIRONMENT": 7,
+    "CENTER": 8,
+    "SCALE": 9,
+    "COMBINED_ALPHA": 10,
+    "TEXEL0_ALPHA": 11,
+    "TEXEL1_ALPHA": 12,
+    "PRIMITIVE_ALPHA": 13,
+    "SHADE_ALPHA": 14,
+    "ENV_ALPHA": 15,
+    "LOD_FRACTION": 16,
+    "PRIM_LOD_FRAC": 17,
+    "NOISE": 18,
+    "K4": 19,
+    "K5": 20,
 }
 
-CC2_C = { # TEX0 and TEX1 are swapped
-  "0":               0,
-  "1":               1,
-  "COMBINED":        2,
-  "TEXEL1":          3,
-  "TEXEL0":          4,
-  "PRIMITIVE":       5,
-  "SHADE":           6,
-  "ENVIRONMENT":     7,
-  "CENTER":          8,
-  "SCALE":           9,
-  "COMBINED_ALPHA":  10,
-  "TEXEL1_ALPHA":    11,
-  "TEXEL0_ALPHA":    12,
-  "PRIMITIVE_ALPHA": 13,
-  "SHADE_ALPHA":     14,
-  "ENV_ALPHA":       15,
-  "LOD_FRACTION":    16,
-  "PRIM_LOD_FRAC":   17,
-  "NOISE":           18,
-  "K4":              19,
-  "K5":              20,
+CC2_C = {  # TEX0 and TEX1 are swapped
+    "0": 0,
+    "1": 1,
+    "COMBINED": 2,
+    "TEXEL1": 3,
+    "TEXEL0": 4,
+    "PRIMITIVE": 5,
+    "SHADE": 6,
+    "ENVIRONMENT": 7,
+    "CENTER": 8,
+    "SCALE": 9,
+    "COMBINED_ALPHA": 10,
+    "TEXEL1_ALPHA": 11,
+    "TEXEL0_ALPHA": 12,
+    "PRIMITIVE_ALPHA": 13,
+    "SHADE_ALPHA": 14,
+    "ENV_ALPHA": 15,
+    "LOD_FRACTION": 16,
+    "PRIM_LOD_FRAC": 17,
+    "NOISE": 18,
+    "K4": 19,
+    "K5": 20,
 }
 
 CC1_A = {
-  "0":             0,
-  "1":             1,
-  "COMBINED":      2,
-  "TEXEL0":        3,
-  "TEXEL1":        4,
-  "PRIMITIVE":     5,
-  "SHADE":         6,
-  "ENVIRONMENT":   7,
-  "LOD_FRACTION":  8,
-  "PRIM_LOD_FRAC": 9,
+    "0": 0,
+    "1": 1,
+    "COMBINED": 2,
+    "TEXEL0": 3,
+    "TEXEL1": 4,
+    "PRIMITIVE": 5,
+    "SHADE": 6,
+    "ENVIRONMENT": 7,
+    "LOD_FRACTION": 8,
+    "PRIM_LOD_FRAC": 9,
 }
 
-CC2_A = { # TEX0 and TEX1 are swapped
-  "0":             0,
-  "1":             1,
-  "COMBINED":      2,
-  "TEXEL1":        3,
-  "TEXEL0":        4,
-  "PRIMITIVE":     5,
-  "SHADE":         6,
-  "ENVIRONMENT":   7,
-  "LOD_FRACTION":  8,
-  "PRIM_LOD_FRAC": 9,
+CC2_A = {  # TEX0 and TEX1 are swapped
+    "0": 0,
+    "1": 1,
+    "COMBINED": 2,
+    "TEXEL1": 3,
+    "TEXEL0": 4,
+    "PRIMITIVE": 5,
+    "SHADE": 6,
+    "ENVIRONMENT": 7,
+    "LOD_FRACTION": 8,
+    "PRIM_LOD_FRAC": 9,
 }
 
-SOLID_CC=(0, 0, 0, 5, 
-          0, 0, 0, 5,
-          0, 0, 0, 5, 
-          0, 0, 0, 5)
+SOLID_CC = (0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5, 0, 0, 0, 5)
+
 
 # Fetches CC settings from a given fast64-material
 def get_cc_settings(f3d_mat) -> np.ndarray:
-  c0 = f3d_mat.combiner1
-  c1 = f3d_mat.combiner2
+    c0 = f3d_mat.combiner1
+    c1 = f3d_mat.combiner2
 
-  if f3d_mat.rdp_settings.g_mdsft_cycletype == 'G_CYC_1CYCLE':
-    c1 = c0
+    if f3d_mat.rdp_settings.g_mdsft_cycletype == "G_CYC_1CYCLE":
+        c1 = c0
 
-  return np.array([
-    CC1_C[c0.A      ], CC1_C[c0.B      ], CC1_C[c0.C      ], CC1_C[c0.D      ],
-    CC1_A[c0.A_alpha], CC1_A[c0.B_alpha], CC1_A[c0.C_alpha], CC1_A[c0.D_alpha],
-    CC2_C[c1.A      ], CC2_C[c1.B      ], CC2_C[c1.C      ], CC2_C[c1.D      ],
-    CC2_A[c1.A_alpha], CC2_A[c1.B_alpha], CC2_A[c1.C_alpha], CC2_A[c1.D_alpha],
-  ], dtype=np.int32)
+    return np.array(
+        [
+            CC1_C[c0.A],
+            CC1_C[c0.B],
+            CC1_C[c0.C],
+            CC1_C[c0.D],
+            CC1_A[c0.A_alpha],
+            CC1_A[c0.B_alpha],
+            CC1_A[c0.C_alpha],
+            CC1_A[c0.D_alpha],
+            CC2_C[c1.A],
+            CC2_C[c1.B],
+            CC2_C[c1.C],
+            CC2_C[c1.D],
+            CC2_A[c1.A_alpha],
+            CC2_A[c1.B_alpha],
+            CC2_A[c1.C_alpha],
+            CC2_A[c1.D_alpha],
+        ],
+        dtype=np.int32,
+    )

--- a/material/parser.py
+++ b/material/parser.py
@@ -441,7 +441,7 @@ def f64_material_parse(f3d_mat: "F3DMaterialProperty", always_set: bool, set_lig
         state.tex_size = tuple(getattr(f3d_mat, f"tex{uv_basis}").get_tex_size())
 
     if cc_uses["Texture 0"] and cc_uses["Texture 1"]:
-        f64mat.mip_count = f3d_mat.rdp_settings.num_textures_mipmapped - 1
+        state.mip_count = f3d_mat.rdp_settings.num_textures_mipmapped - 1
     state.prim_depth = (rdp.prim_depth.z, rdp.prim_depth.dz)
 
     from fast64_internal.f3d.f3d_gbi import get_F3D_GBI

--- a/material/parser.py
+++ b/material/parser.py
@@ -12,152 +12,188 @@ from .cc import SOLID_CC, get_cc_settings
 from .blender import get_blender_settings
 from ..globals import F64_GLOBALS
 
+
 @functools.cache
-def quantize(x: float, bits: int, mi=0.0, ma=1.0): # quantize in a range
-  value_count = 2**bits-1
-  range_size = ma - mi
-  return mi + round((x - mi) / range_size * value_count) / value_count * range_size
+def quantize(x: float, bits: int, mi=0.0, ma=1.0):  # quantize in a range
+    value_count = 2**bits - 1
+    range_size = ma - mi
+    return mi + round((x - mi) / range_size * value_count) / value_count * range_size
+
 
 @functools.cache
 def quantize_tuple_cached(t: tuple, bits: int, mi=0.0, ma=1.0):
-  return tuple(quantize(x, bits, mi, ma) for x in t)
+    return tuple(quantize(x, bits, mi, ma) for x in t)
+
 
 def quantize_tuple(t, bits: int, mi=0.0, ma=1.0):
-  return quantize_tuple_cached(tuple(t), bits, mi, ma)
+    return quantize_tuple_cached(tuple(t), bits, mi, ma)
+
 
 @functools.cache
 def quantize_srgb_cached(linear_color: tuple, include_alpha: bool, force_alpha: bool):
-  result = list(mathutils.Color(linear_color[:3]).from_scene_linear_to_srgb())
-  if include_alpha or force_alpha:
-    if len(linear_color) > 3 and not force_alpha:
-      result.append(linear_color[3])
-    else:
-      result.append(1.0)
-  return quantize_tuple(result, 8)
+    result = list(mathutils.Color(linear_color[:3]).from_scene_linear_to_srgb())
+    if include_alpha or force_alpha:
+        if len(linear_color) > 3 and not force_alpha:
+            result.append(linear_color[3])
+        else:
+            result.append(1.0)
+    return quantize_tuple(result, 8)
 
-def quantize_srgb(linear_color, include_alpha=True, force_alpha=False): # caching this makes it basically free in subsequent frames
-  return quantize_srgb_cached(tuple(linear_color), include_alpha, force_alpha)
+
+def quantize_srgb(
+    linear_color, include_alpha=True, force_alpha=False
+):  # caching this makes it basically free in subsequent frames
+    return quantize_srgb_cached(tuple(linear_color), include_alpha, force_alpha)
+
 
 GEO_MODE_ATTRS = [
-  "g_zbuffer",
-  "g_shade",
-  "g_cull_front",
-  "g_cull_back",
-  "g_ambocclusion",
-  "g_attroffset_z_enable",
-  "g_attroffset_st_enable",
-  "g_packed_normals",
-  "g_lighttoalpha",
-  "g_lighting_specular",
-  "g_fresnel_color",
-  "g_fresnel_alpha",
-  "g_fog",
-  "g_lighting",
-  "g_tex_gen",
-  "g_tex_gen_linear",
-  "g_lod",
-  "g_shade_smooth",
-  "g_clipping",
+    "g_zbuffer",
+    "g_shade",
+    "g_cull_front",
+    "g_cull_back",
+    "g_ambocclusion",
+    "g_attroffset_z_enable",
+    "g_attroffset_st_enable",
+    "g_packed_normals",
+    "g_lighttoalpha",
+    "g_lighting_specular",
+    "g_fresnel_color",
+    "g_fresnel_alpha",
+    "g_fog",
+    "g_lighting",
+    "g_tex_gen",
+    "g_tex_gen_linear",
+    "g_lod",
+    "g_shade_smooth",
+    "g_clipping",
 ]
 
 OTHERMODE_L_ATTRS = [
-  "g_mdsft_alpha_compare",
-  "g_mdsft_zsrcsel",
+    "g_mdsft_alpha_compare",
+    "g_mdsft_zsrcsel",
 ]
 
 OTHERMODE_H_ATTRS = [
-  "g_mdsft_alpha_dither",
-  "g_mdsft_rgb_dither",
-  "g_mdsft_combkey",
-  "g_mdsft_textconv",
-  "g_mdsft_text_filt",
-  "g_mdsft_textlod",
-  "g_mdsft_textdetail",
-  "g_mdsft_textpersp",
-  "g_mdsft_cycletype",
-  "g_mdsft_pipeline",
-  # tlut
+    "g_mdsft_alpha_dither",
+    "g_mdsft_rgb_dither",
+    "g_mdsft_combkey",
+    "g_mdsft_textconv",
+    "g_mdsft_text_filt",
+    "g_mdsft_textlod",
+    "g_mdsft_textdetail",
+    "g_mdsft_textpersp",
+    "g_mdsft_cycletype",
+    "g_mdsft_pipeline",
+    # tlut
 ]
 
-DRAW_FLAG_DECAL        = (1 << 0)
-DRAW_FLAG_ALPHA_BLEND  = (1 << 1)
+DRAW_FLAG_DECAL = 1 << 0
+DRAW_FLAG_ALPHA_BLEND = 1 << 1
+
 
 @dataclass
-class RenderMode: # one class for all rendermodes
-  aa_en: bool = False
-  z_cmp: bool = False
-  z_upd: bool = False
-  im_rd: bool = False
-  clr_on_cvg: bool = False
-  cvg_dst: str = "CVG_DST_CLAMP"
-  zmode: str = "ZMODE_OPA"
-  cvg_x_alpha: bool = False
-  alpha_cvg_sel: bool = False
-  force_bl: bool = False
-  blend_cycle1: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
-  blend_cycle2: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
+class RenderMode:  # one class for all rendermodes
+    aa_en: bool = False
+    z_cmp: bool = False
+    z_upd: bool = False
+    im_rd: bool = False
+    clr_on_cvg: bool = False
+    cvg_dst: str = "CVG_DST_CLAMP"
+    zmode: str = "ZMODE_OPA"
+    cvg_x_alpha: bool = False
+    alpha_cvg_sel: bool = False
+    force_bl: bool = False
+    blend_cycle1: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
+    blend_cycle2: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
+
 
 @functools.cache
-def parse_f3d_rendermode_preset(preset_cycle1: str, preset_cycle2: str|None):
-  # TODO: If/When porting to fast64 reuse this in rendermode_preset_to_advanced (where the logic is sourced)
-  from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
-  f3d = get_F3D_GBI()
-  def get_with_default(preset, default):
-    return getattr(f3d, preset, default)
+def parse_f3d_rendermode_preset(preset_cycle1: str, preset_cycle2: str | None):
+    # TODO: If/When porting to fast64 reuse this in rendermode_preset_to_advanced (where the logic is sourced)
+    from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
 
-  if preset_cycle2 is not None:
-      r1 = get_with_default(preset_cycle1, f3d.G_RM_FOG_SHADE_A)
-      r2 = get_with_default(preset_cycle2, f3d.G_RM_AA_ZB_OPA_SURF2)
-      r = r1 | r2
-  else:
-      r = get_with_default(preset_cycle1, f3d.G_RM_AA_ZB_OPA_SURF)
-      r1 = r
-      # The cycle 1 bits are copied to the cycle 2 bits at export if in 1-cycle mode
-      # (the hardware requires them to be the same). So, here we also move the cycle 1
-      # bits to the cycle 2 slots. r2 is only read for the cycle dependent settings below.
-      r2 = r >> 2
+    f3d = get_F3D_GBI()
 
-  return RenderMode(
-    (r & f3d.AA_EN) != 0,
-    (r & f3d.Z_CMP) != 0,
-    (r & f3d.Z_UPD) != 0,
-    (r & f3d.IM_RD) != 0,
-    (r & f3d.CLR_ON_CVG) != 0,
-    f3d.cvgDstDict[r & f3d.CVG_DST_SAVE],
-    f3d.zmodeDict[r & f3d.ZMODE_DEC],
-    (r & f3d.CVG_X_ALPHA) != 0,
-    (r & f3d.ALPHA_CVG_SEL) != 0,
-    (r & f3d.FORCE_BL) != 0,
-    (f3d.blendColorDict[(r1 >> 30) & 3], f3d.blendAlphaDict[(r1 >> 26) & 3], f3d.blendColorDict[(r1 >> 22) & 3], f3d.blendMixDict[(r1 >> 18) & 3]),
-    (f3d.blendColorDict[(r2 >> 28) & 3], f3d.blendAlphaDict[(r2 >> 24) & 3], f3d.blendColorDict[(r2 >> 20) & 3], f3d.blendMixDict[(r2 >> 16) & 3])
-  )
+    def get_with_default(preset, default):
+        return getattr(f3d, preset, default)
+
+    if preset_cycle2 is not None:
+        r1 = get_with_default(preset_cycle1, f3d.G_RM_FOG_SHADE_A)
+        r2 = get_with_default(preset_cycle2, f3d.G_RM_AA_ZB_OPA_SURF2)
+        r = r1 | r2
+    else:
+        r = get_with_default(preset_cycle1, f3d.G_RM_AA_ZB_OPA_SURF)
+        r1 = r
+        # The cycle 1 bits are copied to the cycle 2 bits at export if in 1-cycle mode
+        # (the hardware requires them to be the same). So, here we also move the cycle 1
+        # bits to the cycle 2 slots. r2 is only read for the cycle dependent settings below.
+        r2 = r >> 2
+
+    return RenderMode(
+        (r & f3d.AA_EN) != 0,
+        (r & f3d.Z_CMP) != 0,
+        (r & f3d.Z_UPD) != 0,
+        (r & f3d.IM_RD) != 0,
+        (r & f3d.CLR_ON_CVG) != 0,
+        f3d.cvgDstDict[r & f3d.CVG_DST_SAVE],
+        f3d.zmodeDict[r & f3d.ZMODE_DEC],
+        (r & f3d.CVG_X_ALPHA) != 0,
+        (r & f3d.ALPHA_CVG_SEL) != 0,
+        (r & f3d.FORCE_BL) != 0,
+        (
+            f3d.blendColorDict[(r1 >> 30) & 3],
+            f3d.blendAlphaDict[(r1 >> 26) & 3],
+            f3d.blendColorDict[(r1 >> 22) & 3],
+            f3d.blendMixDict[(r1 >> 18) & 3],
+        ),
+        (
+            f3d.blendColorDict[(r2 >> 28) & 3],
+            f3d.blendAlphaDict[(r2 >> 24) & 3],
+            f3d.blendColorDict[(r2 >> 20) & 3],
+            f3d.blendMixDict[(r2 >> 16) & 3],
+        ),
+    )
+
 
 def parse_f3d_mat_rendermode(f3d_mat):
-  rdp = f3d_mat.rdp_settings
-  if not rdp.rendermode_advanced_enabled:
-    return parse_f3d_rendermode_preset(rdp.rendermode_preset_cycle_1, rdp.rendermode_preset_cycle_2 if rdp.g_mdsft_cycletype == "G_CYC_2CYCLE" else None)
-  result = RenderMode()
-  for attr in ("aa_en", "z_cmp", "z_cmp", "im_rd", "clr_on_cvg", "cvg_dst", "zmode", "cvg_x_alpha", "alpha_cvg_sel", "force_bl"):
-    setattr(result, attr, getattr(rdp, attr))
-  result.blend_cycle1 = (rdp.blend_p1, rdp.blend_a1, rdp.blend_m1, rdp.blend_b1)
-  if rdp.g_mdsft_cycletype != "G_CYC_2CYCLE":
-   result.blend_cycle2 = result.blend_cycle1
-  else:
-    result.blend_cycle2 = (rdp.blend_p2, rdp.blend_a2, rdp.blend_m2, rdp.blend_b2)
-  return result
+    rdp = f3d_mat.rdp_settings
+    if not rdp.rendermode_advanced_enabled:
+        return parse_f3d_rendermode_preset(
+            rdp.rendermode_preset_cycle_1,
+            rdp.rendermode_preset_cycle_2 if rdp.g_mdsft_cycletype == "G_CYC_2CYCLE" else None,
+        )
+    result = RenderMode()
+    for attr in (
+        "aa_en",
+        "z_cmp",
+        "z_cmp",
+        "im_rd",
+        "clr_on_cvg",
+        "cvg_dst",
+        "zmode",
+        "cvg_x_alpha",
+        "alpha_cvg_sel",
+        "force_bl",
+    ):
+        setattr(result, attr, getattr(rdp, attr))
+    result.blend_cycle1 = (rdp.blend_p1, rdp.blend_a1, rdp.blend_m1, rdp.blend_b1)
+    if rdp.g_mdsft_cycletype != "G_CYC_2CYCLE":
+        result.blend_cycle2 = result.blend_cycle1
+    else:
+        result.blend_cycle2 = (rdp.blend_p2, rdp.blend_a2, rdp.blend_m2, rdp.blend_b2)
+    return result
 
-LIGHT_STRUCT = "4f 3f 4x"         # color, direction, padding
-TILE_STRUCT = "2f 2f 2f 2f i 12x" # mask, shift, low, high, flags, padding
+
+LIGHT_STRUCT = "4f 3f 4x"  # color, direction, padding
+TILE_STRUCT = "2f 2f 2f 2f i 12x"  # mask, shift, low, high, flags, padding
 
 UNIFORM_BUFFER_STRUCT = struct.Struct(
-  (TILE_STRUCT * 8) +             # texture configurations
-  (LIGHT_STRUCT * 8) +            # lights
-  "8i"                            # blender
-  "16i"                           # color-combiner settings
-  "i i i i"                       # geoMode, other-low, other-high, flags
-  "4f 4f 4f 4f"                   # prim, prim_lod, prim-depth, env, ambient
-  "3f f 3f i 3f i"                # ck center, alpha clip, ck scale, light count, width, mipmap count
-  "6f 2i"                         # k0-k5, tex size
+    (TILE_STRUCT * 8) + (LIGHT_STRUCT * 8) + "8i"  # texture configurations, lights, blender
+    "16i"  # color-combiner settings
+    "i i i i"  # geoMode, other-low, other-high, flags
+    "4f 4f 4f 4f"  # prim, prim_lod, prim-depth, env, ambient
+    "3f f 3f i 3f i"  # ck center, alpha clip, ck scale, light count, width, mipmap count
+    "6f 2i"  # k0-k5, tex size
 )
 # version of the uniform buffer with all ints
 UNIFORM_BUFFER_MASK_STRUCT = struct.Struct(UNIFORM_BUFFER_STRUCT.format.replace("f", "I").replace("i", "I"))
@@ -167,246 +203,284 @@ F64Color = tuple[float, float, float, float]
 
 @dataclass
 class F64Rendermode:
-  blender: tuple[int, int, int, int, int, int, int, int] = (0, 0, 0, 0, 0, 0, 0, 0)
-  flags: int = 0
-  blend: str = 'NONE'
-  depth_test: str = 'LESS_EQUAL'
-  depth_write: bool = True
-  alpha_clip: float = -1
+    blender: tuple[int, int, int, int, int, int, int, int] = (0, 0, 0, 0, 0, 0, 0, 0)
+    flags: int = 0
+    blend: str = "NONE"
+    depth_test: str = "LESS_EQUAL"
+    depth_write: bool = True
+    alpha_clip: float = -1
 
 
 @dataclass
 class F64Light:
-  color: F64Color = (0, 0, 0, 0)
-  direction: tuple[float, float, float]|None = None
+    color: F64Color = (0, 0, 0, 0)
+    direction: tuple[float, float, float] | None = None
 
 
 @dataclass
 class F64RenderState:
-  tex_confs: list[F64Texture | None] = None
-  lights: list[F64Light|None] = None
-  ambient_color: F64Color|None = None
-  light_count: int|None = None
-  prim_color: F64Color|None = None
-  prim_lod: tuple[float, float]|None = None
-  env_color: F64Color|None = None
-  ck: tuple[float, float, float, float, float, float, float, float]|None = None
-  convert: tuple[float, float, float, float, float, float]|None = None
-  cc: tuple[float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float]|None = None
-  render_mode: F64Rendermode|None = None
-  flags: int = 0
-  geo_mode: int = 0
-  othermode_l: int = 0
-  othermode_h: int = 0
-  prim_depth: tuple[float, float] = None
-  tex_size: tuple[int, int] = None
-  mip_count: int = None
+    tex_confs: list[F64Texture | None] = None
+    lights: list[F64Light | None] = None
+    ambient_color: F64Color | None = None
+    light_count: int | None = None
+    prim_color: F64Color | None = None
+    prim_lod: tuple[float, float] | None = None
+    env_color: F64Color | None = None
+    ck: tuple[float, float, float, float, float, float, float, float] | None = None
+    convert: tuple[float, float, float, float, float, float] | None = None
+    cc: tuple[
+        float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float
+    ] | None = None
+    render_mode: F64Rendermode | None = None
+    flags: int = 0
+    geo_mode: int = 0
+    othermode_l: int = 0
+    othermode_h: int = 0
+    prim_depth: tuple[float, float] = None
+    tex_size: tuple[int, int] = None
+    mip_count: int = None
 
-  cached_values: np.ndarray|None = None
-  cached_mask: np.ndarray|None = None
+    cached_values: np.ndarray | None = None
+    cached_mask: np.ndarray | None = None
 
-  def __post_init__(self):
-    if self.lights is None: self.lights = [None] * 8
-    if self.tex_confs is None: self.tex_confs = [None] * 8
+    def __post_init__(self):
+        if self.lights is None:
+            self.lights = [None] * 8
+        if self.tex_confs is None:
+            self.tex_confs = [None] * 8
 
-  def save_cache(self):
-    self.cached_values = self.np_array(False)
-    self.cached_mask = self.np_array(True)
+    def save_cache(self):
+        self.cached_values = self.np_array(False)
+        self.cached_mask = self.np_array(True)
 
-  def np_array(self, make_mask: bool=False):
-    if make_mask:
-      def mask(value: None|object, size: int=1, mask_value: int=0xFFFFFFFF):
-        return (mask_value if value is None else 0,) * size
-      def mask_single(value: None|object, mask_value: int=0xFFFFFFFF):
-        return mask_value if value is None else 0
-      ubo_struct = UNIFORM_BUFFER_MASK_STRUCT
-    else:
-      def mask(value: None|object, size: int=1, _mask_value=0):
-        if value is None: return (0,) * size
-        return value
-      def mask_single(value: None|object, _mask_value=0):
-        return 0 if value is None else value
-      ubo_struct = UNIFORM_BUFFER_STRUCT
+    def np_array(self, make_mask: bool = False):
+        if make_mask:
 
-    light_data = []
-    for l in self.lights:
-      if l is None: light_data.extend(mask(None, 7))
-      else:
-        light_data.extend(mask(l.color, 4))
-        light_data.extend(mask(l.direction, 3))
-    tex_data = []
-    for t in self.tex_confs:
-      if t is None: tex_data.extend(mask(None, 9))
-      else: tex_data.extend(mask(t.values, 9))
-    
-    blender, alpha_clip, flags = None, -1, self.flags
-    if self.render_mode is not None: 
-      blender = self.render_mode.blender
-      alpha_clip = self.render_mode.alpha_clip
-      flags |= self.render_mode.flags
+            def mask(value: None | object, size: int = 1, mask_value: int = 0xFFFFFFFF):
+                return (mask_value if value is None else 0,) * size
 
-    ck = self.ck
-    if ck is None:
-      ck = (0,) * 9
+            def mask_single(value: None | object, mask_value: int = 0xFFFFFFFF):
+                return mask_value if value is None else 0
 
-    return np.frombuffer(
-      ubo_struct.pack(
-        *tex_data,
-        *light_data,
-        *mask(blender, 8),
-        *mask(self.cc, 16),
-        mask_single(self.geo_mode),
-        mask_single(self.othermode_l),
-        mask_single(self.othermode_h),
-        mask_single(flags),
-        *mask(self.prim_color, 4),
-        *mask(self.prim_lod, 2),
-        *mask(self.prim_depth, 2),
-        *mask(self.env_color, 4),
-        *mask(self.ambient_color, 4),
-        *mask(ck[:3], 3),
-        mask_single(alpha_clip),
-        *mask(ck[3:6], 3),
-        mask_single(self.light_count),
-        *mask(ck[6:9], 3),
-        mask_single(self.mip_count),
-        *mask(self.convert, 6),
-        *mask(self.tex_size, 2),
-      ),
-      dtype=np.uint64
-    )
-  
-  def set_values_from_cache(self, other: "F64RenderState"):
-    self.cached_values = (self.cached_values & other.cached_mask) | other.cached_values
-    for i, other_conf in enumerate(other.tex_confs):
-      if other_conf is not None: self.tex_confs[i] = other_conf
-    if other.render_mode is not None: self.render_mode = other.render_mode
+            ubo_struct = UNIFORM_BUFFER_MASK_STRUCT
+        else:
 
-  def copy(self):
-    new = copy.copy(self)
-    new.cached_values = new.cached_values.copy()
-    return new
+            def mask(value: None | object, size: int = 1, _mask_value=0):
+                if value is None:
+                    return (0,) * size
+                return value
 
-  def set_from_rendermode(self, rendermode: RenderMode):
-    self.render_mode = F64Rendermode(get_blender_settings(rendermode.blend_cycle1, rendermode.blend_cycle2),  depth_write=rendermode.z_upd)
-    if rendermode.zmode == 'ZMODE_DEC':
-      self.render_mode.depth_test = 'EQUAL'
-      self.render_mode.flags |= DRAW_FLAG_DECAL
-    if rendermode.cvg_x_alpha:
-      self.render_mode.alpha_clip = 0.49
-    else:
-      self.render_mode.alpha_clip = -1
-    if rendermode.force_bl and rendermode.blend_cycle2 == ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_MEM", "G_BL_1MA"):
-      self.render_mode.blend = "ALPHA"
-      self.render_mode.flags |= DRAW_FLAG_ALPHA_BLEND
+            def mask_single(value: None | object, _mask_value=0):
+                return 0 if value is None else value
+
+            ubo_struct = UNIFORM_BUFFER_STRUCT
+
+        light_data = []
+        for l in self.lights:
+            if l is None:
+                light_data.extend(mask(None, 7))
+            else:
+                light_data.extend(mask(l.color, 4))
+                light_data.extend(mask(l.direction, 3))
+        tex_data = []
+        for t in self.tex_confs:
+            if t is None:
+                tex_data.extend(mask(None, 9))
+            else:
+                tex_data.extend(mask(t.values, 9))
+
+        blender, alpha_clip, flags = None, -1, self.flags
+        if self.render_mode is not None:
+            blender = self.render_mode.blender
+            alpha_clip = self.render_mode.alpha_clip
+            flags |= self.render_mode.flags
+
+        ck = self.ck
+        if ck is None:
+            ck = (0,) * 9
+
+        return np.frombuffer(
+            ubo_struct.pack(
+                *tex_data,
+                *light_data,
+                *mask(blender, 8),
+                *mask(self.cc, 16),
+                mask_single(self.geo_mode),
+                mask_single(self.othermode_l),
+                mask_single(self.othermode_h),
+                mask_single(flags),
+                *mask(self.prim_color, 4),
+                *mask(self.prim_lod, 2),
+                *mask(self.prim_depth, 2),
+                *mask(self.env_color, 4),
+                *mask(self.ambient_color, 4),
+                *mask(ck[:3], 3),
+                mask_single(alpha_clip),
+                *mask(ck[3:6], 3),
+                mask_single(self.light_count),
+                *mask(ck[6:9], 3),
+                mask_single(self.mip_count),
+                *mask(self.convert, 6),
+                *mask(self.tex_size, 2),
+            ),
+            dtype=np.uint64,
+        )
+
+    def set_values_from_cache(self, other: "F64RenderState"):
+        self.cached_values = (self.cached_values & other.cached_mask) | other.cached_values
+        for i, other_conf in enumerate(other.tex_confs):
+            if other_conf is not None:
+                self.tex_confs[i] = other_conf
+        if other.render_mode is not None:
+            self.render_mode = other.render_mode
+
+    def copy(self):
+        new = copy.copy(self)
+        new.cached_values = new.cached_values.copy()
+        return new
+
+    def set_from_rendermode(self, rendermode: RenderMode):
+        self.render_mode = F64Rendermode(
+            get_blender_settings(rendermode.blend_cycle1, rendermode.blend_cycle2), depth_write=rendermode.z_upd
+        )
+        if rendermode.zmode == "ZMODE_DEC":
+            self.render_mode.depth_test = "EQUAL"
+            self.render_mode.flags |= DRAW_FLAG_DECAL
+        if rendermode.cvg_x_alpha:
+            self.render_mode.alpha_clip = 0.49
+        else:
+            self.render_mode.alpha_clip = -1
+        if rendermode.force_bl and rendermode.blend_cycle2 == ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_MEM", "G_BL_1MA"):
+            self.render_mode.blend = "ALPHA"
+            self.render_mode.flags |= DRAW_FLAG_ALPHA_BLEND
 
 
 @dataclass
 class F64Material:
-  state: F64RenderState = dataclasses.field(default_factory=F64RenderState)
-  cull: str = 'NONE'
-  layer: int|str|None = None
+    state: F64RenderState = dataclasses.field(default_factory=F64RenderState)
+    cull: str = "NONE"
+    layer: int | str | None = None
 
 
 def quantize_direction(direction):
-  return tuple(quantize(x, 8, -1, 1) for x in direction)
+    return tuple(quantize(x, 8, -1, 1) for x in direction)
+
 
 def f64_parse_obj_light(f64_light: F64Light, obj: bpy.types.Object, set_light_dir: bool):
-  from fast64_internal.utility import getObjDirectionVec
-  f64_light.color = quantize_srgb(obj.data.color, force_alpha=True)
-  if set_light_dir: f64_light.direction = quantize_direction(getObjDirectionVec(obj, False))
-  else: f64_light.direction = None
+    from fast64_internal.utility import getObjDirectionVec
+
+    f64_light.color = quantize_srgb(obj.data.color, force_alpha=True)
+    if set_light_dir:
+        f64_light.direction = quantize_direction(getObjDirectionVec(obj, False))
+    else:
+        f64_light.direction = None
+
 
 DEFAULT_LIGHT_DIR = quantize_direction(mathutils.Vector((0x49, 0x49, 0x49)).normalized())
 
+
 def f64_material_parse(f3d_mat: "F3DMaterialProperty", always_set: bool, set_light_dir: bool) -> F64Material:
-  from fast64_internal.f3d.f3d_material import all_combiner_uses
-  from fast64_internal.f3d.f3d_writer import lightDataToObj
+    from fast64_internal.f3d.f3d_material import all_combiner_uses
+    from fast64_internal.f3d.f3d_writer import lightDataToObj
 
-  cc_uses = all_combiner_uses(f3d_mat)
-  rdp = f3d_mat.rdp_settings
+    cc_uses = all_combiner_uses(f3d_mat)
+    rdp = f3d_mat.rdp_settings
 
-  state = F64RenderState() # None equals not set
-  f64mat = F64Material(state=state)
-  if always_set or rdp.set_rendermode: state.set_from_rendermode(parse_f3d_mat_rendermode(f3d_mat))
-  if always_set or f3d_mat.set_combiner: state.cc = get_cc_settings(f3d_mat)
-  if always_set or (f3d_mat.set_prim and cc_uses['Primitive']): 
-    state.prim_color = quantize_srgb(f3d_mat.prim_color)
-    state.prim_lod = (f3d_mat.prim_lod_frac, f3d_mat.prim_lod_min)
-  if always_set or (f3d_mat.set_env and cc_uses['Environment']): 
-    state.env_color = quantize_srgb(f3d_mat.env_color)
-  if always_set or (f3d_mat.set_key and cc_uses['Key']): # extra 0 for alignment
-    state.ck = tuple((*quantize_srgb(f3d_mat.key_center, False), *f3d_mat.key_scale, *f3d_mat.key_width))
-  if always_set or (f3d_mat.set_k0_5 and cc_uses['Convert']):
-    state.convert = tuple(getattr(f3d_mat, f"k{i}") for i in range(0, 6))
-  if always_set or (cc_uses["Shade"] and rdp.g_lighting and f3d_mat.set_lights):
-    state.ambient_color = quantize_srgb(f3d_mat.ambient_light_color, force_alpha=True)
-    if f3d_mat.use_default_lighting:
-      state.light_count = 1
-      state.lights[0] = F64Light(quantize_srgb(f3d_mat.default_light_color, force_alpha=True))
-      if set_light_dir: state.lights[0].direction = DEFAULT_LIGHT_DIR
-    else:
-      light_index = 0
-      for i in range(0, 7):
-        light_data = getattr(f3d_mat, f"f3d_light{i + 1}", None)
-        if light_data is None:
-          continue
-        obj = lightDataToObj(light_data.original)
-        f64_light = state.lights[light_index] = F64_GLOBALS.obj_lights.setdefault(obj.name, F64Light())
-        f64_parse_obj_light(f64_light, obj, set_light_dir)
-        light_index += 1
-      state.light_count = light_index
+    state = F64RenderState()  # None equals not set
+    f64mat = F64Material(state=state)
+    if always_set or rdp.set_rendermode:
+        state.set_from_rendermode(parse_f3d_mat_rendermode(f3d_mat))
+    if always_set or f3d_mat.set_combiner:
+        state.cc = get_cc_settings(f3d_mat)
+    if always_set or (f3d_mat.set_prim and cc_uses["Primitive"]):
+        state.prim_color = quantize_srgb(f3d_mat.prim_color)
+        state.prim_lod = (f3d_mat.prim_lod_frac, f3d_mat.prim_lod_min)
+    if always_set or (f3d_mat.set_env and cc_uses["Environment"]):
+        state.env_color = quantize_srgb(f3d_mat.env_color)
+    if always_set or (f3d_mat.set_key and cc_uses["Key"]):  # extra 0 for alignment
+        state.ck = tuple((*quantize_srgb(f3d_mat.key_center, False), *f3d_mat.key_scale, *f3d_mat.key_width))
+    if always_set or (f3d_mat.set_k0_5 and cc_uses["Convert"]):
+        state.convert = tuple(getattr(f3d_mat, f"k{i}") for i in range(0, 6))
+    if always_set or (cc_uses["Shade"] and rdp.g_lighting and f3d_mat.set_lights):
+        state.ambient_color = quantize_srgb(f3d_mat.ambient_light_color, force_alpha=True)
+        if f3d_mat.use_default_lighting:
+            state.light_count = 1
+            state.lights[0] = F64Light(quantize_srgb(f3d_mat.default_light_color, force_alpha=True))
+            if set_light_dir:
+                state.lights[0].direction = DEFAULT_LIGHT_DIR
+        else:
+            light_index = 0
+            for i in range(0, 7):
+                light_data = getattr(f3d_mat, f"f3d_light{i + 1}", None)
+                if light_data is None:
+                    continue
+                obj = lightDataToObj(light_data.original)
+                f64_light = state.lights[light_index] = F64_GLOBALS.obj_lights.setdefault(obj.name, F64Light())
+                f64_parse_obj_light(f64_light, obj, set_light_dir)
+                light_index += 1
+            state.light_count = light_index
 
-  if rdp.g_cull_back: f64mat.cull = "BACK"
-  if rdp.g_cull_front: 
-    f64mat.cull = "BOTH" if f64mat.cull == "BACK" else "FRONT"
+    if rdp.g_cull_back:
+        f64mat.cull = "BACK"
+    if rdp.g_cull_front:
+        f64mat.cull = "BOTH" if f64mat.cull == "BACK" else "FRONT"
 
-  use_tex0, use_tex1 = f3d_mat.tex0.tex_set and cc_uses["Texture 0"], f3d_mat.tex1.tex_set and cc_uses["Texture 1"]
-  if use_tex0: state.tex_confs[0] = get_tile_conf(f3d_mat.tex0)
-  if use_tex1: state.tex_confs[1] = get_tile_conf(f3d_mat.tex1)
-  # TODO: use check for multitex function in glTF pr?
+    use_tex0, use_tex1 = f3d_mat.tex0.tex_set and cc_uses["Texture 0"], f3d_mat.tex1.tex_set and cc_uses["Texture 1"]
+    if use_tex0:
+        state.tex_confs[0] = get_tile_conf(f3d_mat.tex0)
+    if use_tex1:
+        state.tex_confs[1] = get_tile_conf(f3d_mat.tex1)
+    # TODO: use check for multitex function in glTF pr?
 
-  uv_basis = None
-  if use_tex0 and use_tex1: uv_basis = int(f3d_mat.uv_basis.removeprefix("TEXEL"))
-  elif use_tex0 or use_tex1: uv_basis = 0 if use_tex0 else 1
-  if uv_basis is not None: state.tex_size = tuple(getattr(f3d_mat, f"tex{uv_basis}").get_tex_size())
+    uv_basis = None
+    if use_tex0 and use_tex1:
+        uv_basis = int(f3d_mat.uv_basis.removeprefix("TEXEL"))
+    elif use_tex0 or use_tex1:
+        uv_basis = 0 if use_tex0 else 1
+    if uv_basis is not None:
+        state.tex_size = tuple(getattr(f3d_mat, f"tex{uv_basis}").get_tex_size())
 
-  if cc_uses["Texture 0"] and cc_uses["Texture 1"]: f64mat.mip_count = f3d_mat.rdp_settings.num_textures_mipmapped - 1
-  state.prim_depth = (rdp.prim_depth.z, rdp.prim_depth.dz)
-  
-  from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
-  from fast64_internal.f3d.f3d_material import get_textlut_mode
-  gbi = get_F3D_GBI()
-  geo_mode = othermode_l = othermode_h = 0
-  # TODO: use geo_modes_in_ucode (T3D UI pr) to check if the geo mode exists in the current ucode
-  for i, attr in enumerate(GEO_MODE_ATTRS):
-    if not getattr(gbi, attr.upper().replace("G_TEX_GEN", "G_TEXTURE_GEN").replace("G_SHADE_SMOOTH", "G_SHADING_SMOOTH"), False):
-      continue
-    geo_mode |= int(getattr(rdp, attr)) << i
-  for i, attr in enumerate(OTHERMODE_L_ATTRS):
-    othermode_l |= getattr(gbi, getattr(rdp, attr))
-  for i, attr in enumerate(OTHERMODE_H_ATTRS):
-    othermode_h |= getattr(gbi, getattr(rdp, attr))
-  if rdp.g_mdsft_cycletype == 'G_CYC_COPY':
-    othermode_h ^= gbi.G_TF_BILERP | gbi.G_TF_AVERAGE
-  othermode_h |= getattr(gbi, get_textlut_mode(f3d_mat))
-  state.geo_mode, state.othermode_l, state.othermode_h = geo_mode, othermode_l, othermode_h
-  state.save_cache()
+    if cc_uses["Texture 0"] and cc_uses["Texture 1"]:
+        f64mat.mip_count = f3d_mat.rdp_settings.num_textures_mipmapped - 1
+    state.prim_depth = (rdp.prim_depth.z, rdp.prim_depth.dz)
 
-  game_mode = bpy.context.scene.gameEditorMode
-  f64mat.layer = getattr(f3d_mat.draw_layer, game_mode.lower(), None)
+    from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
+    from fast64_internal.f3d.f3d_material import get_textlut_mode
 
-  return f64mat
+    gbi = get_F3D_GBI()
+    geo_mode = othermode_l = othermode_h = 0
+    # TODO: use geo_modes_in_ucode (T3D UI pr) to check if the geo mode exists in the current ucode
+    for i, attr in enumerate(GEO_MODE_ATTRS):
+        if not getattr(
+            gbi, attr.upper().replace("G_TEX_GEN", "G_TEXTURE_GEN").replace("G_SHADE_SMOOTH", "G_SHADING_SMOOTH"), False
+        ):
+            continue
+        geo_mode |= int(getattr(rdp, attr)) << i
+    for i, attr in enumerate(OTHERMODE_L_ATTRS):
+        othermode_l |= getattr(gbi, getattr(rdp, attr))
+    for i, attr in enumerate(OTHERMODE_H_ATTRS):
+        othermode_h |= getattr(gbi, getattr(rdp, attr))
+    if rdp.g_mdsft_cycletype == "G_CYC_COPY":
+        othermode_h ^= gbi.G_TF_BILERP | gbi.G_TF_AVERAGE
+    othermode_h |= getattr(gbi, get_textlut_mode(f3d_mat))
+    state.geo_mode, state.othermode_l, state.othermode_h = geo_mode, othermode_l, othermode_h
+    state.save_cache()
+
+    game_mode = bpy.context.scene.gameEditorMode
+    f64mat.layer = getattr(f3d_mat.draw_layer, game_mode.lower(), None)
+
+    return f64mat
+
 
 # parses a non-f3d material for the fallback renderer
 def node_material_parse(mat: bpy.types.Material) -> F64Material:
-  # TODO: If bsdf to f3d gets merged into fast, consider using that?
-  color = None
-  if mat.use_nodes:
-    bsdf = mat.node_tree.nodes.get('Principled BSDF')
-    if bsdf:
-      color = quantize_srgb(bsdf.inputs['Base Color'].default_value)
+    # TODO: If bsdf to f3d gets merged into fast, consider using that?
+    color = None
+    if mat.use_nodes:
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            color = quantize_srgb(bsdf.inputs["Base Color"].default_value)
 
-  state = F64RenderState(prim_color=color, cc=SOLID_CC)
-  state.save_cache()
-  return F64Material(state)
+    state = F64RenderState(prim_color=color, cc=SOLID_CC)
+    state.save_cache()
+    return F64Material(state)

--- a/material/parser.py
+++ b/material/parser.py
@@ -1,12 +1,42 @@
-from dataclasses import dataclass, field
+import copy
+from dataclasses import dataclass
+import dataclasses
+import functools
+import struct
 import bpy
+import mathutils
 import numpy as np
-import gpu
-import time
 
-from .tile import get_tile_conf
-from .cc import get_cc_settings
+from .tile import get_tile_conf, F64Texture
+from .cc import SOLID_CC, get_cc_settings
 from .blender import get_blender_settings
+from ..globals import F64_GLOBALS
+
+@functools.cache
+def quantize(x: float, bits: int, mi=0.0, ma=1.0): # quantize in a range
+  value_count = 2**bits-1
+  range_size = ma - mi
+  return mi + round((x - mi) / range_size * value_count) / value_count * range_size
+
+@functools.cache
+def quantize_tuple_cached(t: tuple, bits: int, mi=0.0, ma=1.0):
+  return tuple(quantize(x, bits, mi, ma) for x in t)
+
+def quantize_tuple(t, bits: int, mi=0.0, ma=1.0):
+  return quantize_tuple_cached(tuple(t), bits, mi, ma)
+
+@functools.cache
+def quantize_srgb_cached(linear_color: tuple, include_alpha: bool, force_alpha: bool):
+  result = list(mathutils.Color(linear_color[:3]).from_scene_linear_to_srgb())
+  if include_alpha or force_alpha:
+    if len(linear_color) > 3 and not force_alpha:
+      result.append(linear_color[3])
+    else:
+      result.append(1.0)
+  return quantize_tuple(result, 8)
+
+def quantize_srgb(linear_color, include_alpha=True, force_alpha=False): # caching this makes it basically free in subsequent frames
+  return quantize_srgb_cached(tuple(linear_color), include_alpha, force_alpha)
 
 GEO_MODE_ATTRS = [
   "g_zbuffer",
@@ -49,119 +79,301 @@ OTHERMODE_H_ATTRS = [
   # tlut
 ]
 
-DRAW_FLAG_TEX0_MONO    = (1 << 1)
-DRAW_FLAG_TEX1_MONO    = (1 << 2)
-DRAW_FLAG_DECAL        = (1 << 3)
-DRAW_FLAG_ALPHA_BLEND  = (1 << 4)
-DRAW_FLAG_TEX0_4BIT    = (1 << 5)
-DRAW_FLAG_TEX1_4BIT    = (1 << 6)
-DRAW_FLAG_TEX0_3BIT    = (1 << 7)
-DRAW_FLAG_TEX1_3BIT    = (1 << 8)
+DRAW_FLAG_DECAL        = (1 << 0)
+DRAW_FLAG_ALPHA_BLEND  = (1 << 1)
+
+@dataclass
+class RenderMode: # one class for all rendermodes
+  aa_en: bool = False
+  z_cmp: bool = False
+  z_upd: bool = False
+  im_rd: bool = False
+  clr_on_cvg: bool = False
+  cvg_dst: str = "CVG_DST_CLAMP"
+  zmode: str = "ZMODE_OPA"
+  cvg_x_alpha: bool = False
+  alpha_cvg_sel: bool = False
+  force_bl: bool = False
+  blend_cycle1: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
+  blend_cycle2: tuple[str, str, str, str] = ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_IN", "G_BL_1MA")
+
+@functools.cache
+def parse_f3d_rendermode_preset(preset_cycle1: str, preset_cycle2: str|None):
+  # TODO: If/When porting to fast64 reuse this in rendermode_preset_to_advanced (where the logic is sourced)
+  from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
+  f3d = get_F3D_GBI()
+  def get_with_default(preset, default):
+    return getattr(f3d, preset, default)
+
+  if preset_cycle2 is not None:
+      r1 = get_with_default(preset_cycle1, f3d.G_RM_FOG_SHADE_A)
+      r2 = get_with_default(preset_cycle2, f3d.G_RM_AA_ZB_OPA_SURF2)
+      r = r1 | r2
+  else:
+      r = get_with_default(preset_cycle1, f3d.G_RM_AA_ZB_OPA_SURF)
+      r1 = r
+      # The cycle 1 bits are copied to the cycle 2 bits at export if in 1-cycle mode
+      # (the hardware requires them to be the same). So, here we also move the cycle 1
+      # bits to the cycle 2 slots. r2 is only read for the cycle dependent settings below.
+      r2 = r >> 2
+
+  return RenderMode(
+    (r & f3d.AA_EN) != 0,
+    (r & f3d.Z_CMP) != 0,
+    (r & f3d.Z_UPD) != 0,
+    (r & f3d.IM_RD) != 0,
+    (r & f3d.CLR_ON_CVG) != 0,
+    f3d.cvgDstDict[r & f3d.CVG_DST_SAVE],
+    f3d.zmodeDict[r & f3d.ZMODE_DEC],
+    (r & f3d.CVG_X_ALPHA) != 0,
+    (r & f3d.ALPHA_CVG_SEL) != 0,
+    (r & f3d.FORCE_BL) != 0,
+    (f3d.blendColorDict[(r1 >> 30) & 3], f3d.blendAlphaDict[(r1 >> 26) & 3], f3d.blendColorDict[(r1 >> 22) & 3], f3d.blendMixDict[(r1 >> 18) & 3]),
+    (f3d.blendColorDict[(r2 >> 28) & 3], f3d.blendAlphaDict[(r2 >> 24) & 3], f3d.blendColorDict[(r2 >> 20) & 3], f3d.blendMixDict[(r2 >> 16) & 3])
+  )
+
+def parse_f3d_mat_rendermode(f3d_mat):
+  rdp = f3d_mat.rdp_settings
+  if not rdp.rendermode_advanced_enabled:
+    return parse_f3d_rendermode_preset(rdp.rendermode_preset_cycle_1, rdp.rendermode_preset_cycle_2 if rdp.g_mdsft_cycletype == "G_CYC_2CYCLE" else None)
+  result = RenderMode()
+  for attr in ("aa_en", "z_cmp", "z_cmp", "im_rd", "clr_on_cvg", "cvg_dst", "zmode", "cvg_x_alpha", "alpha_cvg_sel", "force_bl"):
+    setattr(result, attr, getattr(rdp, attr))
+  result.blend_cycle1 = (rdp.blend_p1, rdp.blend_a1, rdp.blend_m1, rdp.blend_b1)
+  if rdp.g_mdsft_cycletype != "G_CYC_2CYCLE":
+   result.blend_cycle2 = result.blend_cycle1
+  else:
+    result.blend_cycle2 = (rdp.blend_p2, rdp.blend_a2, rdp.blend_m2, rdp.blend_b2)
+  return result
+
+LIGHT_STRUCT = "4f 3f 4x"         # color, direction, padding
+TILE_STRUCT = "2f 2f 2f 2f i 12x" # mask, shift, low, high, flags, padding
+
+UNIFORM_BUFFER_STRUCT = struct.Struct(
+  (TILE_STRUCT * 8) +             # texture configurations
+  (LIGHT_STRUCT * 8) +            # lights
+  "8i"                            # blender
+  "16i"                           # color-combiner settings
+  "i i i i"                       # geoMode, other-low, other-high, flags
+  "4f 4f 4f 4f"                   # prim, prim_lod, prim-depth, env, ambient
+  "3f f 3f i 3f i"                # ck center, alpha clip, ck scale, light count, width, mipmap count
+  "6f 2i"                         # k0-k5, tex size
+)
+# version of the uniform buffer with all ints
+UNIFORM_BUFFER_MASK_STRUCT = struct.Struct(UNIFORM_BUFFER_STRUCT.format.replace("f", "I").replace("i", "I"))
+
+F64Color = tuple[float, float, float, float]
+
+
+@dataclass
+class F64Rendermode:
+  blender: tuple[int, int, int, int, int, int, int, int] = (0, 0, 0, 0, 0, 0, 0, 0)
+  flags: int = 0
+  blend: str = 'NONE'
+  depth_test: str = 'LESS_EQUAL'
+  depth_write: bool = True
+  alpha_clip: float = -1
+
+
+@dataclass
+class F64Light:
+  color: F64Color = (0, 0, 0, 0)
+  direction: tuple[float, float, float]|None = None
+
+
+@dataclass
+class F64RenderState:
+  tex_confs: list[F64Texture | None] = None
+  lights: list[F64Light|None] = None
+  ambient_color: F64Color|None = None
+  light_count: int|None = None
+  prim_color: F64Color|None = None
+  prim_lod: tuple[float, float]|None = None
+  env_color: F64Color|None = None
+  ck: tuple[float, float, float, float, float, float, float, float]|None = None
+  convert: tuple[float, float, float, float, float, float]|None = None
+  cc: tuple[float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float]|None = None
+  render_mode: F64Rendermode|None = None
+  flags: int = 0
+  geo_mode: int = 0
+  othermode_l: int = 0
+  othermode_h: int = 0
+  prim_depth: tuple[float, float] = None
+  tex_size: tuple[int, int] = None
+  mip_count: int = None
+
+  cached_values: np.ndarray|None = None
+  cached_mask: np.ndarray|None = None
+
+  def __post_init__(self):
+    if self.lights is None: self.lights = [None] * 8
+    if self.tex_confs is None: self.tex_confs = [None] * 8
+
+  def save_cache(self):
+    self.cached_values = self.np_array(False)
+    self.cached_mask = self.np_array(True)
+
+  def np_array(self, make_mask: bool=False):
+    if make_mask:
+      def mask(value: None|object, size: int=1, mask_value: int=0xFFFFFFFF):
+        return (mask_value if value is None else 0,) * size
+      def mask_single(value: None|object, mask_value: int=0xFFFFFFFF):
+        return mask_value if value is None else 0
+      ubo_struct = UNIFORM_BUFFER_MASK_STRUCT
+    else:
+      def mask(value: None|object, size: int=1, _mask_value=0):
+        if value is None: return (0,) * size
+        return value
+      def mask_single(value: None|object, _mask_value=0):
+        return 0 if value is None else value
+      ubo_struct = UNIFORM_BUFFER_STRUCT
+
+    light_data = []
+    for l in self.lights:
+      if l is None: light_data.extend(mask(None, 7))
+      else:
+        light_data.extend(mask(l.color, 4))
+        light_data.extend(mask(l.direction, 3))
+    tex_data = []
+    for t in self.tex_confs:
+      if t is None: tex_data.extend(mask(None, 9))
+      else: tex_data.extend(mask(t.values, 9))
+    
+    blender, alpha_clip, flags = None, -1, self.flags
+    if self.render_mode is not None: 
+      blender = self.render_mode.blender
+      alpha_clip = self.render_mode.alpha_clip
+      flags |= self.render_mode.flags
+
+    ck = self.ck
+    if ck is None:
+      ck = (0,) * 9
+
+    return np.frombuffer(
+      ubo_struct.pack(
+        *tex_data,
+        *light_data,
+        *mask(blender, 8),
+        *mask(self.cc, 16),
+        mask_single(self.geo_mode),
+        mask_single(self.othermode_l),
+        mask_single(self.othermode_h),
+        mask_single(flags),
+        *mask(self.prim_color, 4),
+        *mask(self.prim_lod, 2),
+        *mask(self.prim_depth, 2),
+        *mask(self.env_color, 4),
+        *mask(self.ambient_color, 4),
+        *mask(ck[:3], 3),
+        mask_single(alpha_clip),
+        *mask(ck[3:6], 3),
+        mask_single(self.light_count),
+        *mask(ck[6:9], 3),
+        mask_single(self.mip_count),
+        *mask(self.convert, 6),
+        *mask(self.tex_size, 2),
+      ),
+      dtype=np.uint64
+    )
+  
+  def set_values_from_cache(self, other: "F64RenderState"):
+    self.cached_values = (self.cached_values & other.cached_mask) | other.cached_values
+    for i, other_conf in enumerate(other.tex_confs):
+      if other_conf is not None: self.tex_confs[i] = other_conf
+    if other.render_mode is not None: self.render_mode = other.render_mode
+
+  def copy(self):
+    new = copy.copy(self)
+    new.cached_values = new.cached_values.copy()
+    return new
+
+  def set_from_rendermode(self, rendermode: RenderMode):
+    self.render_mode = F64Rendermode(get_blender_settings(rendermode.blend_cycle1, rendermode.blend_cycle2),  depth_write=rendermode.z_upd)
+    if rendermode.zmode == 'ZMODE_DEC':
+      self.render_mode.depth_test = 'EQUAL'
+      self.render_mode.flags |= DRAW_FLAG_DECAL
+    if rendermode.cvg_x_alpha:
+      self.render_mode.alpha_clip = 0.49
+    else:
+      self.render_mode.alpha_clip = -1
+    if rendermode.force_bl and rendermode.blend_cycle2 == ("G_BL_CLR_IN", "G_BL_A_IN", "G_BL_CLR_MEM", "G_BL_1MA"):
+      self.render_mode.blend = "ALPHA"
+      self.render_mode.flags |= DRAW_FLAG_ALPHA_BLEND
+
 
 @dataclass
 class F64Material:
-    color_prim: tuple = field(default_factory=lambda: (1, 1, 1, 1))
-    lod_prim: tuple = field(default_factory=lambda: (0, 0))
-    prim_depth: tuple = field(default_factory=lambda: (0, 0))
-    color_env: tuple = field(default_factory=lambda: (0.5, 0.5, 0.5, 0.5))
-    ck: tuple = field(default_factory=lambda: (0, 0, 0, 0, 0, 0, 0, 0))
-    convert: tuple = field(default_factory=lambda: (0, 0, 0, 0, 0, 0))
-    color_ambient: tuple = None
-    color_light: tuple= None
-    
-    set_prim: bool = False
-    set_env: bool = False
-    set_ck: bool = False
-    set_convert: bool = False
-    set_ambient: bool = False
-    set_light: bool = False
-
-    cc: np.ndarray = None
-    blender: tuple = None
-    tile_conf: np.ndarray = None
-    cull: str = 'NONE'
-    flags: int = 0
-    geo_mode: int = 0
-    othermode_l: int = 0
-    othermode_h: int = 0
-    alphaClip: float = -1.0
-    queue: int = 0
-    tex0Buff: gpu.types.GPUTexture = None
-    tex1Buff: gpu.types.GPUTexture = None
+  state: F64RenderState = dataclasses.field(default_factory=F64RenderState)
+  cull: str = 'NONE'
+  layer: int|str|None = None
 
 
-# parses a non-f3d material for the fallback renderer
-def node_material_parse(mat: bpy.types.Material) -> F64Material:
-  color = np.array([1, 1, 1, 1], dtype=np.float32)
-  if mat.use_nodes:
-    bsdf = mat.node_tree.nodes.get('Principled BSDF')
-    if bsdf:
-      base_color = bsdf.inputs['Base Color'].default_value
-      color = np.array([base_color[0], base_color[1], base_color[2], 1], dtype=np.float32)
+def quantize_direction(direction):
+  return tuple(quantize(x, 8, -1, 1) for x in direction)
 
-  return F64Material(color, color)
+def f64_parse_obj_light(f64_light: F64Light, obj: bpy.types.Object, set_light_dir: bool):
+  from fast64_internal.utility import getObjDirectionVec
+  f64_light.color = quantize_srgb(obj.data.color, force_alpha=True)
+  if set_light_dir: f64_light.direction = quantize_direction(getObjDirectionVec(obj, False))
+  else: f64_light.direction = None
 
-# @TODO: re-use fast64 logic
-def f64_parse_blend_mode(f3d_mat: any, f64mat: F64Material) -> str:
-  f64mat.alphaClip = -1
-  is_one_cycle = f3d_mat.rdp_settings.g_mdsft_cycletype == "G_CYC_1CYCLE"
+DEFAULT_LIGHT_DIR = quantize_direction(mathutils.Vector((0x49, 0x49, 0x49)).normalized())
 
-  if f3d_mat.rdp_settings.set_rendermode:
-    if f3d_mat.rdp_settings.cvg_x_alpha:
-        f64mat.alphaClip = 0.49
-    elif (
-        is_one_cycle
-        and f3d_mat.rdp_settings.force_bl
-        and f3d_mat.rdp_settings.blend_p1 == "G_BL_CLR_IN"
-        and f3d_mat.rdp_settings.blend_a1 == "G_BL_A_IN"
-        and f3d_mat.rdp_settings.blend_m1 == "G_BL_CLR_MEM"
-        and f3d_mat.rdp_settings.blend_b1 == "G_BL_1MA"
-    ):
-        f64mat.flags |= DRAW_FLAG_ALPHA_BLEND
-    elif (
-        not is_one_cycle
-        and f3d_mat.rdp_settings.force_bl
-        and f3d_mat.rdp_settings.blend_p2 == "G_BL_CLR_IN"
-        and f3d_mat.rdp_settings.blend_a2 == "G_BL_A_IN"
-        and f3d_mat.rdp_settings.blend_m2 == "G_BL_CLR_MEM"
-        and f3d_mat.rdp_settings.blend_b2 == "G_BL_1MA"
-    ):
-        f64mat.flags |= DRAW_FLAG_ALPHA_BLEND
-
-def f64_material_parse(f3d_mat: any, prev_f64mat: F64Material) -> F64Material:
-  from fast64_internal.utility import s_rgb_alpha_1_tuple, gammaCorrect
+def f64_material_parse(f3d_mat: "F3DMaterialProperty", always_set: bool, set_light_dir: bool) -> F64Material:
   from fast64_internal.f3d.f3d_material import all_combiner_uses
+  from fast64_internal.f3d.f3d_writer import lightDataToObj
+
   cc_uses = all_combiner_uses(f3d_mat)
+  rdp = f3d_mat.rdp_settings
 
-  f64mat = F64Material(
-     color_prim = gammaCorrect(f3d_mat.prim_color),
-     lod_prim   = [f3d_mat.prim_lod_min, f3d_mat.prim_lod_frac],
-     prim_depth = [f3d_mat.rdp_settings.prim_depth.z, f3d_mat.rdp_settings.prim_depth.dz],
-     set_prim   = f3d_mat.set_prim and cc_uses['Primitive'],
-     color_env  = gammaCorrect(f3d_mat.env_color),
-     set_env    = f3d_mat.set_env and cc_uses['Environment'],
-     ck         = tuple((*s_rgb_alpha_1_tuple(f3d_mat.key_center), *f3d_mat.key_scale, 0)), # extra 0 for alignment
-     set_ck     = f3d_mat.set_key and cc_uses['Key'],
-     convert    = [getattr(f3d_mat, f"k{i}") for i in range(0, 6)],
-     set_convert= f3d_mat.set_k0_5 and cc_uses['Convert'],
-     color_ambient = s_rgb_alpha_1_tuple(f3d_mat.ambient_light_color),
-     color_light = s_rgb_alpha_1_tuple(f3d_mat.default_light_color),
-     set_ambient = f3d_mat.set_lights,
-     set_light   = f3d_mat.set_lights, # shared flag
+  state = F64RenderState() # None equals not set
+  f64mat = F64Material(state=state)
+  if always_set or rdp.set_rendermode: state.set_from_rendermode(parse_f3d_mat_rendermode(f3d_mat))
+  if always_set or f3d_mat.set_combiner: state.cc = get_cc_settings(f3d_mat)
+  if always_set or (f3d_mat.set_prim and cc_uses['Primitive']): 
+    state.prim_color = quantize_srgb(f3d_mat.prim_color)
+    state.prim_lod = (f3d_mat.prim_lod_frac, f3d_mat.prim_lod_min)
+  if always_set or (f3d_mat.set_env and cc_uses['Environment']): 
+    state.env_color = quantize_srgb(f3d_mat.env_color)
+  if always_set or (f3d_mat.set_key and cc_uses['Key']): # extra 0 for alignment
+    state.ck = tuple((*quantize_srgb(f3d_mat.key_center, False), *f3d_mat.key_scale, *f3d_mat.key_width))
+  if always_set or (f3d_mat.set_k0_5 and cc_uses['Convert']):
+    state.convert = tuple(getattr(f3d_mat, f"k{i}") for i in range(0, 6))
+  if always_set or (cc_uses["Shade"] and rdp.g_lighting and f3d_mat.set_lights):
+    state.ambient_color = quantize_srgb(f3d_mat.ambient_light_color, force_alpha=True)
+    if f3d_mat.use_default_lighting:
+      state.light_count = 1
+      state.lights[0] = F64Light(quantize_srgb(f3d_mat.default_light_color, force_alpha=True))
+      if set_light_dir: state.lights[0].direction = DEFAULT_LIGHT_DIR
+    else:
+      light_index = 0
+      for i in range(0, 7):
+        light_data = getattr(f3d_mat, f"f3d_light{i + 1}", None)
+        if light_data is None:
+          continue
+        obj = lightDataToObj(light_data.original)
+        f64_light = state.lights[light_index] = F64_GLOBALS.obj_lights.setdefault(obj.name, F64Light())
+        f64_parse_obj_light(f64_light, obj, set_light_dir)
+        light_index += 1
+      state.light_count = light_index
 
-     flags = 0,
-     cc = get_cc_settings(f3d_mat),
-     blender= get_blender_settings(f3d_mat)
-  )
+  if rdp.g_cull_back: f64mat.cull = "BACK"
+  if rdp.g_cull_front: 
+    f64mat.cull = "BOTH" if f64mat.cull == "BACK" else "FRONT"
 
-  f64mat.color_prim.append(f3d_mat.prim_color[3])
-  f64mat.color_env.append(f3d_mat.env_color[3])
+  use_tex0, use_tex1 = f3d_mat.tex0.tex_set and cc_uses["Texture 0"], f3d_mat.tex1.tex_set and cc_uses["Texture 1"]
+  if use_tex0: state.tex_confs[0] = get_tile_conf(f3d_mat.tex0)
+  if use_tex1: state.tex_confs[1] = get_tile_conf(f3d_mat.tex1)
+  # TODO: use check for multitex function in glTF pr?
 
-  if f3d_mat.rdp_settings.g_cull_back: f64mat.cull = "BACK"
-  if f3d_mat.rdp_settings.g_cull_front: f64mat.cull = "FRONT"
+  uv_basis = None
+  if use_tex0 and use_tex1: uv_basis = int(f3d_mat.uv_basis.removeprefix("TEXEL"))
+  elif use_tex0 or use_tex1: uv_basis = 0 if use_tex0 else 1
+  if uv_basis is not None: state.tex_size = tuple(getattr(f3d_mat, f"tex{uv_basis}").get_tex_size())
+
+  if cc_uses["Texture 0"] and cc_uses["Texture 1"]: f64mat.mip_count = f3d_mat.rdp_settings.num_textures_mipmapped - 1
+  state.prim_depth = (rdp.prim_depth.z, rdp.prim_depth.dz)
   
-  f64_parse_blend_mode(f3d_mat, f64mat)
-
   from fast64_internal.f3d.f3d_gbi import get_F3D_GBI
   from fast64_internal.f3d.f3d_material import get_textlut_mode
   gbi = get_F3D_GBI()
@@ -170,48 +382,31 @@ def f64_material_parse(f3d_mat: any, prev_f64mat: F64Material) -> F64Material:
   for i, attr in enumerate(GEO_MODE_ATTRS):
     if not getattr(gbi, attr.upper().replace("G_TEX_GEN", "G_TEXTURE_GEN").replace("G_SHADE_SMOOTH", "G_SHADING_SMOOTH"), False):
       continue
-    geo_mode |= int(getattr(f3d_mat.rdp_settings, attr)) << i
+    geo_mode |= int(getattr(rdp, attr)) << i
   for i, attr in enumerate(OTHERMODE_L_ATTRS):
-    othermode_l |= getattr(gbi, getattr(f3d_mat.rdp_settings, attr))
+    othermode_l |= getattr(gbi, getattr(rdp, attr))
   for i, attr in enumerate(OTHERMODE_H_ATTRS):
-    othermode_h |= getattr(gbi, getattr(f3d_mat.rdp_settings, attr))
+    othermode_h |= getattr(gbi, getattr(rdp, attr))
+  if rdp.g_mdsft_cycletype == 'G_CYC_COPY':
+    othermode_h ^= gbi.G_TF_BILERP | gbi.G_TF_AVERAGE
   othermode_h |= getattr(gbi, get_textlut_mode(f3d_mat))
-  f64mat.geo_mode, f64mat.othermode_l, f64mat.othermode_h = geo_mode, othermode_l, othermode_h
-  
-  if f3d_mat.draw_layer.oot == 'Transparent' or f3d_mat.draw_layer.sm64 in ['5', '6','7']:
-    f64mat.queue = 1
+  state.geo_mode, state.othermode_l, state.othermode_h = geo_mode, othermode_l, othermode_h
+  state.save_cache()
 
-  if f3d_mat.rdp_settings.zmode == 'ZMODE_DEC':
-    f64mat.flags |= DRAW_FLAG_DECAL
-
-  # Note: doing 'gpu.texture.from_image' seems to cost nothing, caching is not needed
-  if f3d_mat.tex0.tex_set:
-    if f3d_mat.tex0.tex:
-      f64mat.tex0Buff = gpu.texture.from_image(f3d_mat.tex0.tex)
-      if f3d_mat.tex0.tex_format == 'I4' or f3d_mat.tex0.tex_format == 'I8':
-        f64mat.flags |= DRAW_FLAG_TEX0_MONO
-      if f3d_mat.tex0.tex_format == 'I4' or f3d_mat.tex0.tex_format == 'IA8':
-        f64mat.flags |= DRAW_FLAG_TEX0_4BIT
-      if f3d_mat.tex0.tex_format == 'IA4':
-        f64mat.flags |= DRAW_FLAG_TEX0_3BIT
-    else:
-      f64mat.tex0Buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
-      f64mat.flags |= DRAW_FLAG_TEX0_MONO
-
-  if f3d_mat.tex1.tex_set:
-    if f3d_mat.tex1.tex:
-      f64mat.tex1Buff = gpu.texture.from_image(f3d_mat.tex1.tex)
-      if f3d_mat.tex1.tex_format == 'I4' or f3d_mat.tex1.tex_format == 'I8':
-        f64mat.flags |= DRAW_FLAG_TEX1_MONO
-      if f3d_mat.tex1.tex_format == 'I4' or f3d_mat.tex1.tex_format == 'IA8':
-        f64mat.flags |= DRAW_FLAG_TEX1_4BIT
-      if f3d_mat.tex1.tex_format == 'IA4':
-        f64mat.flags |= DRAW_FLAG_TEX1_3BIT
-    else:
-      f64mat.tex1Buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
-      f64mat.flags |= DRAW_FLAG_TEX1_MONO
-
-
-  f64mat.tile_conf = get_tile_conf(f3d_mat)
+  game_mode = bpy.context.scene.gameEditorMode
+  f64mat.layer = getattr(f3d_mat.draw_layer, game_mode.lower(), None)
 
   return f64mat
+
+# parses a non-f3d material for the fallback renderer
+def node_material_parse(mat: bpy.types.Material) -> F64Material:
+  # TODO: If bsdf to f3d gets merged into fast, consider using that?
+  color = None
+  if mat.use_nodes:
+    bsdf = mat.node_tree.nodes.get('Principled BSDF')
+    if bsdf:
+      color = quantize_srgb(bsdf.inputs['Base Color'].default_value)
+
+  state = F64RenderState(prim_color=color, cc=SOLID_CC)
+  state.save_cache()
+  return F64Material(state)

--- a/material/tile.py
+++ b/material/tile.py
@@ -1,33 +1,52 @@
+import bpy
+import gpu
+
+from dataclasses import dataclass
 import numpy as np
 
-def get_tile_conf(f3d_mat) -> np.ndarray:
-  t0 = f3d_mat.tex0
-  t1 = f3d_mat.tex1
+TEX_FLAG_MONO    = (1 << 0)
+TEX_FLAG_4BIT    = (1 << 1)
+TEX_FLAG_3BIT    = (1 << 2)
+
+@dataclass
+class F64Texture:
+  values: tuple[float, float, float, float, float, float, float, float, int]
+  buff: gpu.types.GPUTexture
+
+def get_tile_conf(tex: "TextureProperty") -> F64Texture:
+  flags = 0
+  if tex.tex is not None: 
+    # Note: doing 'gpu.texture.from_image' seems to cost nothing, caching is not needed
+    buff = gpu.texture.from_image(tex.tex)
+    if tex.tex_format in {"I4", "I8"}:
+      flags |= TEX_FLAG_MONO
+    if tex.tex_format in {"I4", "IA8"}:
+      flags |= TEX_FLAG_4BIT
+    if tex.tex_format == 'IA4':
+      flags |= TEX_FLAG_3BIT
+  else:
+    buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
+    flags |= TEX_FLAG_MONO
 
   conf = np.array([
-  #    X            Y           Z           W
-    t0.S.mask,   t0.T.mask,  t1.S.mask,   t1.T.mask,
-    t0.S.shift,  t0.T.shift, t1.S.shift,  t1.T.shift,
-    t0.S.low,   -t0.T.low,   t1.S.low,   -t1.T.low,
-    t0.S.high,   t0.T.high,  t1.S.high,   t1.T.high,
+    tex.S.mask,   tex.T.mask,
+    tex.S.shift,  tex.T.shift,
+    tex.S.low,   -tex.T.low,
+    tex.S.high,   tex.T.high,
   ], dtype=np.float32)
 
-  conf[0:8] = 2 ** conf[0:8] # mask/shift are exponents, calc. 2^x
-  conf[4:8] = 1 / conf[4:8] # shift is inverted
+  conf[0:4] = 2 ** conf[0:4] # mask/shift are exponents, calc. 2^x
+  conf[2:4] = 1 / conf[2:4]  # shift is inverted
   
   # quantize the low/high values into 0.25 pixel increments
-  conf[8:] = np.round(conf[8:] * 4) / 4
+  conf[4:] = np.round(conf[4:] * 4) / 4
 
   # if clamp is on, negate the mask value
-  if t0.S.clamp: conf[0] = -conf[0]
-  if t0.T.clamp: conf[1] = -conf[1]
-  if t1.S.clamp: conf[2] = -conf[2]
-  if t1.T.clamp: conf[3] = -conf[3]
+  if tex.S.clamp: conf[0] = -conf[0]
+  if tex.T.clamp: conf[1] = -conf[1]
 
   # if mirror is on, negate the high value
-  if t0.S.mirror: conf[12] = -conf[12]
-  if t0.T.mirror: conf[13] = -conf[13]
-  if t1.S.mirror: conf[14] = -conf[14]
-  if t1.T.mirror: conf[15] = -conf[15]
+  if tex.S.mirror: conf[6] = -conf[6]
+  if tex.T.mirror: conf[7] = -conf[7]
   
-  return conf
+  return F64Texture((*conf, flags), buff)

--- a/material/tile.py
+++ b/material/tile.py
@@ -4,49 +4,62 @@ import gpu
 from dataclasses import dataclass
 import numpy as np
 
-TEX_FLAG_MONO    = (1 << 0)
-TEX_FLAG_4BIT    = (1 << 1)
-TEX_FLAG_3BIT    = (1 << 2)
+TEX_FLAG_MONO = 1 << 0
+TEX_FLAG_4BIT = 1 << 1
+TEX_FLAG_3BIT = 1 << 2
+
 
 @dataclass
 class F64Texture:
-  values: tuple[float, float, float, float, float, float, float, float, int]
-  buff: gpu.types.GPUTexture
+    values: tuple[float, float, float, float, float, float, float, float, int]
+    buff: gpu.types.GPUTexture
+
 
 def get_tile_conf(tex: "TextureProperty") -> F64Texture:
-  flags = 0
-  if tex.tex is not None: 
-    # Note: doing 'gpu.texture.from_image' seems to cost nothing, caching is not needed
-    buff = gpu.texture.from_image(tex.tex)
-    if tex.tex_format in {"I4", "I8"}:
-      flags |= TEX_FLAG_MONO
-    if tex.tex_format in {"I4", "IA8"}:
-      flags |= TEX_FLAG_4BIT
-    if tex.tex_format == 'IA4':
-      flags |= TEX_FLAG_3BIT
-  else:
-    buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
-    flags |= TEX_FLAG_MONO
+    flags = 0
+    if tex.tex is not None:
+        # Note: doing 'gpu.texture.from_image' seems to cost nothing, caching is not needed
+        buff = gpu.texture.from_image(tex.tex)
+        if tex.tex_format in {"I4", "I8"}:
+            flags |= TEX_FLAG_MONO
+        if tex.tex_format in {"I4", "IA8"}:
+            flags |= TEX_FLAG_4BIT
+        if tex.tex_format == "IA4":
+            flags |= TEX_FLAG_3BIT
+    else:
+        buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
+        flags |= TEX_FLAG_MONO
 
-  conf = np.array([
-    tex.S.mask,   tex.T.mask,
-    tex.S.shift,  tex.T.shift,
-    tex.S.low,   -tex.T.low,
-    tex.S.high,   tex.T.high,
-  ], dtype=np.float32)
+    conf = np.array(
+        [
+            tex.S.mask,
+            tex.T.mask,
+            tex.S.shift,
+            tex.T.shift,
+            tex.S.low,
+            -tex.T.low,
+            tex.S.high,
+            tex.T.high,
+        ],
+        dtype=np.float32,
+    )
 
-  conf[0:4] = 2 ** conf[0:4] # mask/shift are exponents, calc. 2^x
-  conf[2:4] = 1 / conf[2:4]  # shift is inverted
-  
-  # quantize the low/high values into 0.25 pixel increments
-  conf[4:] = np.round(conf[4:] * 4) / 4
+    conf[0:4] = 2 ** conf[0:4]  # mask/shift are exponents, calc. 2^x
+    conf[2:4] = 1 / conf[2:4]  # shift is inverted
 
-  # if clamp is on, negate the mask value
-  if tex.S.clamp: conf[0] = -conf[0]
-  if tex.T.clamp: conf[1] = -conf[1]
+    # quantize the low/high values into 0.25 pixel increments
+    conf[4:] = np.round(conf[4:] * 4) / 4
 
-  # if mirror is on, negate the high value
-  if tex.S.mirror: conf[6] = -conf[6]
-  if tex.T.mirror: conf[7] = -conf[7]
-  
-  return F64Texture((*conf, flags), buff)
+    # if clamp is on, negate the mask value
+    if tex.S.clamp:
+        conf[0] = -conf[0]
+    if tex.T.clamp:
+        conf[1] = -conf[1]
+
+    # if mirror is on, negate the high value
+    if tex.S.mirror:
+        conf[6] = -conf[6]
+    if tex.T.mirror:
+        conf[7] = -conf[7]
+
+    return F64Texture((*conf, flags), buff)

--- a/mesh/gpu_batch.py
+++ b/mesh/gpu_batch.py
@@ -1,17 +1,19 @@
 import numpy as np
 import gpu
 
-def create_vert_buf(vbo_format, 
-    buff_vert: np.ndarray, buff_norm: np.ndarray, buff_color: np.ndarray, buff_uv: np.ndarray
+
+def create_vert_buf(
+    vbo_format, buff_vert: np.ndarray, buff_norm: np.ndarray, buff_color: np.ndarray, buff_uv: np.ndarray
 ) -> list[gpu.types.GPUBatch]:
     vbo = gpu.types.GPUVertBuf(vbo_format, len(buff_vert))
 
-    vbo.attr_fill("pos",        buff_vert)
-    vbo.attr_fill("inNormal",   buff_norm)
-    vbo.attr_fill("inColor",    buff_color)
-    vbo.attr_fill("inUV",       buff_uv)
+    vbo.attr_fill("pos", buff_vert)
+    vbo.attr_fill("inNormal", buff_norm)
+    vbo.attr_fill("inColor", buff_color)
+    vbo.attr_fill("inUV", buff_uv)
 
     return vbo
+
 
 # Stripped down version of blender own batch function, specific to our layout
 def batch_for_shader(vbo: gpu.types.GPUVertBuf, indices: np.ndarray) -> list[gpu.types.GPUBatch]:

--- a/mesh/gpu_batch.py
+++ b/mesh/gpu_batch.py
@@ -1,19 +1,20 @@
 import numpy as np
 import gpu
 
-# Stripped down version of blender own batch function, specific to our layout
-def batch_for_shader(shader, 
-    buff_vert: np.ndarray, buff_norm: np.ndarray, buff_color: np.ndarray, buff_uv: np.ndarray, 
-    indices: np.ndarray
+def create_vert_buf(vbo_format, 
+    buff_vert: np.ndarray, buff_norm: np.ndarray, buff_color: np.ndarray, buff_uv: np.ndarray
 ) -> list[gpu.types.GPUBatch]:
-    type = "TRIS"
-    vbo_format = shader.format_calc()
     vbo = gpu.types.GPUVertBuf(vbo_format, len(buff_vert))
 
-    vbo.attr_fill("pos",    buff_vert)
-    vbo.attr_fill("inNormal", buff_norm)
-    vbo.attr_fill("inColor",  buff_color)
-    vbo.attr_fill("inUV",     buff_uv)
-    
-    ibo = gpu.types.GPUIndexBuf(type=type, seq=indices)
-    return gpu.types.GPUBatch(type=type, buf=vbo, elem=ibo)
+    vbo.attr_fill("pos",        buff_vert)
+    vbo.attr_fill("inNormal",   buff_norm)
+    vbo.attr_fill("inColor",    buff_color)
+    vbo.attr_fill("inUV",       buff_uv)
+
+    return vbo
+
+# Stripped down version of blender own batch function, specific to our layout
+def batch_for_shader(vbo: gpu.types.GPUVertBuf, indices: np.ndarray) -> list[gpu.types.GPUBatch]:
+    typ = "TRIS"
+    ibo = gpu.types.GPUIndexBuf(type=typ, seq=indices)
+    return gpu.types.GPUBatch(type=typ, buf=vbo, elem=ibo)

--- a/mesh/mesh.py
+++ b/mesh/mesh.py
@@ -7,124 +7,128 @@ import time
 import gpu
 from ..material.parser import F64Material
 
+
 # Container for all vertex attributes
 @dataclass
 class MeshBuffers:
-  # input buffers:
+    # input buffers:
     vert: np.ndarray
     color: np.ndarray
     uv: np.ndarray
     norm: np.ndarray
-    indices: np.ndarray # global index array, sorted by material
-    index_offsets: np.ndarray # offsets for each material in the index array
-  # render data:
-    batch: list[gpu.types.GPUBatch]|gpu.types.GPUBatch
+    indices: np.ndarray  # global index array, sorted by material
+    index_offsets: np.ndarray  # offsets for each material in the index array
+    # render data:
+    batch: list[gpu.types.GPUBatch] | gpu.types.GPUBatch
     ubo_mat_data: list[gpu.types.GPUUniformBuf]
     materials: list[F64Material] = None
-    mesh_name: str = "" # multiple obj. can share the same mesh, store to allow deletion by name
+    mesh_name: str = ""  # multiple obj. can share the same mesh, store to allow deletion by name
+
 
 # Converts a blender mesh into buffers to be used by the GPU renderer
 # Note that this can be a slow process, so it should be cached externally
 # This will only handle mesh data itself, materials are not read out here
 def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
-  from fast64_internal.f3d.f3d_writer import getColorLayer
+    from fast64_internal.f3d.f3d_writer import getColorLayer
 
-  tDes = time.process_time()
-  mesh.calc_loop_triangles()
+    tDes = time.process_time()
+    mesh.calc_loop_triangles()
 
-  # Here we want to transform all attributes into un-indexed arrays of per-vertex data
-  # Position + normals are stored per vertex (indexed), colors and uvs are stored per face-corner
-  # All need to be normalized to the same length
+    # Here we want to transform all attributes into un-indexed arrays of per-vertex data
+    # Position + normals are stored per vertex (indexed), colors and uvs are stored per face-corner
+    # All need to be normalized to the same length
 
-  uv_layer = mesh.uv_layers.get("UVMap", mesh.uv_layers.active)
-  if uv_layer is not None:
-    uv_layer = uv_layer.data
+    uv_layer = mesh.uv_layers.get("UVMap", mesh.uv_layers.active)
+    if uv_layer is not None:
+        uv_layer = uv_layer.data
 
-  num_corners = len(mesh.loop_triangles) * 3
-  # print("Faces: ", num_corners, color_layer)
+    num_corners = len(mesh.loop_triangles) * 3
+    # print("Faces: ", num_corners, color_layer)
 
-  positions = np.empty((num_corners, 3), dtype=np.float32)
-  normals   = np.empty((num_corners, 3), dtype=np.float32)
-  colors    = np.empty((num_corners, 4), dtype=np.float32)
-  uvs       = np.empty((num_corners, 2), dtype=np.float32)
+    positions = np.empty((num_corners, 3), dtype=np.float32)
+    normals = np.empty((num_corners, 3), dtype=np.float32)
+    colors = np.empty((num_corners, 4), dtype=np.float32)
+    uvs = np.empty((num_corners, 2), dtype=np.float32)
 
-  indices   = np.empty((num_corners   ), dtype=np.int32)
-  mesh.loop_triangles.foreach_get('vertices', indices)
+    indices = np.empty((num_corners), dtype=np.int32)
+    mesh.loop_triangles.foreach_get("vertices", indices)
 
-  # map vertices to unique face-corner
-  tmp_vec3 = np.empty((len(mesh.vertices), 3), dtype=np.float32)
-  mesh.vertices.foreach_get('co', tmp_vec3.ravel())
-  positions = tmp_vec3[indices]
+    # map vertices to unique face-corner
+    tmp_vec3 = np.empty((len(mesh.vertices), 3), dtype=np.float32)
+    mesh.vertices.foreach_get("co", tmp_vec3.ravel())
+    positions = tmp_vec3[indices]
 
-  # read normals (these contain pre-calculated normals handling  flat, smooth, custom split normals)
-  if bpy.app.version < (4, 0, 0):
-      mesh.calc_normals_split()
-      corner_norm = np.empty((len(mesh.loops), 3), dtype=np.float32)
-      mesh.loops.foreach_get('normal', corner_norm.ravel())
-  else:
-    corner_norm = np.empty((len(mesh.corner_normals), 3), dtype=np.float32)
-    mesh.corner_normals.foreach_get('vector', corner_norm.ravel())
+    # read normals (these contain pre-calculated normals handling  flat, smooth, custom split normals)
+    if bpy.app.version < (4, 0, 0):
+        mesh.calc_normals_split()
+        corner_norm = np.empty((len(mesh.loops), 3), dtype=np.float32)
+        mesh.loops.foreach_get("normal", corner_norm.ravel())
+    else:
+        corner_norm = np.empty((len(mesh.corner_normals), 3), dtype=np.float32)
+        mesh.corner_normals.foreach_get("vector", corner_norm.ravel())
 
-  mesh.loop_triangles.foreach_get('loops', indices)
-  normals = corner_norm[indices]
-  
-  if uv_layer is not None: 
-    corner_uvs = np.empty((len(uv_layer), 2), dtype=np.float32)
-    uv_layer.foreach_get('uv', corner_uvs.ravel())
-    uvs = corner_uvs[indices]
-  else:
-    uvs.fill(0.0)
+    mesh.loop_triangles.foreach_get("loops", indices)
+    normals = corner_norm[indices]
 
-  # HACK: color and alpha layer must be read after the other is used, old blends break otherwise?
-  color_layer = getColorLayer(mesh, layer="Col")
-  if color_layer is not None:
-    colors_tmp = np.empty((len(color_layer), 4), dtype=np.float32)
-    if bpy.app.version > (3, 2, 0):
-      color_layer.foreach_get('color_srgb', colors_tmp.ravel())
-    else: # vectorized linear -> sRGB conversion
-      color_layer.foreach_get('color', colors_tmp.ravel())
-      mask = colors_tmp > 0.0031308
-      colors_tmp[mask] = 1.055 * (np.power(colors_tmp[mask], (1.0 / 2.4))) - 0.055
-      colors_tmp[~mask] *= 12.92
-    colors = colors_tmp[indices]
+    if uv_layer is not None:
+        corner_uvs = np.empty((len(uv_layer), 2), dtype=np.float32)
+        uv_layer.foreach_get("uv", corner_uvs.ravel())
+        uvs = corner_uvs[indices]
+    else:
+        uvs.fill(0.0)
 
-  else:
-    colors.fill(1.0)
+    # HACK: color and alpha layer must be read after the other is used, old blends break otherwise?
+    color_layer = getColorLayer(mesh, layer="Col")
+    if color_layer is not None:
+        colors_tmp = np.empty((len(color_layer), 4), dtype=np.float32)
+        if bpy.app.version > (3, 2, 0):
+            color_layer.foreach_get("color_srgb", colors_tmp.ravel())
+        else:  # vectorized linear -> sRGB conversion
+            color_layer.foreach_get("color", colors_tmp.ravel())
+            mask = colors_tmp > 0.0031308
+            colors_tmp[mask] = 1.055 * (np.power(colors_tmp[mask], (1.0 / 2.4))) - 0.055
+            colors_tmp[~mask] *= 12.92
+        colors = colors_tmp[indices]
 
-  alpha_layer = getColorLayer(mesh, layer="Alpha")
-  if alpha_layer is not None:
-    alpha_tmp = np.empty((len(alpha_layer), 4), dtype=np.float32)
-    alpha_layer.foreach_get('color', alpha_tmp.ravel())
-    colors[:, 3] = alpha_tmp[indices, 0] # TODO: use blender lum convert to match exports?
-  else:
-    colors[:, 3] = 1.0
+    else:
+        colors.fill(1.0)
 
-  # create map of hidden polygons (we need to map that to triangles)
-  poly_hidden = np.empty(len(mesh.polygons), dtype=np.int32)
-  mesh.polygons.foreach_get('hide', poly_hidden)
+    alpha_layer = getColorLayer(mesh, layer="Alpha")
+    if alpha_layer is not None:
+        alpha_tmp = np.empty((len(alpha_layer), 4), dtype=np.float32)
+        alpha_layer.foreach_get("color", alpha_tmp.ravel())
+        colors[:, 3] = alpha_tmp[indices, 0]  # TODO: use blender lum convert to match exports?
+    else:
+        colors[:, 3] = 1.0
 
-  tri_hidden = np.empty(len(mesh.loop_triangles), dtype=np.int32)
-  mesh.loop_triangles.foreach_get('polygon_index', tri_hidden)
-  tri_hidden = poly_hidden[tri_hidden]
+    # create map of hidden polygons (we need to map that to triangles)
+    poly_hidden = np.empty(len(mesh.polygons), dtype=np.int32)
+    mesh.polygons.foreach_get("hide", poly_hidden)
 
-  # create index buffers for the mesh by material, the data behind it is unindexed
-  # this is done to do a cheap split by material
-  mat_count = len(mesh.materials)
+    tri_hidden = np.empty(len(mesh.loop_triangles), dtype=np.int32)
+    mesh.loop_triangles.foreach_get("polygon_index", tri_hidden)
+    tri_hidden = poly_hidden[tri_hidden]
 
-  mat_indices = np.empty(len(mesh.loop_triangles), dtype=np.uint32)
-  mesh.loop_triangles.foreach_get('material_index', mat_indices) # materials, e.g.: [0, 1, 0, 1, 2, 1, ...]
-  index_array = np.arange(num_corners, dtype=np.int32) # -> [0, 1, 2, 3, 4, 5, ...]
-  index_array = index_array.reshape((-1, 3))           # -> [[0, 1, 2], [3, 4, 5], ...]
+    # create index buffers for the mesh by material, the data behind it is unindexed
+    # this is done to do a cheap split by material
+    mat_count = len(mesh.materials)
 
-  # remove faces based on 'tri_hidden' (0=visible, 1=hidden)
-  index_array = index_array[tri_hidden == 0]
-  mat_indices = mat_indices[tri_hidden == 0]
-  
-  index_array = index_array[np.argsort(mat_indices)] # sort index_array by value in use_flat (aka material-index)
-  index_offsets = np.bincount(mat_indices, minlength=mat_count)    # now get counts of each material, e.g.: [1, 2] where index is material-index
-  index_offsets = np.insert(index_offsets, 0, 0)  # prepend 0 to turn counts into offsets
-  index_offsets = np.cumsum(index_offsets)   # converted into accumulated offset
+    mat_indices = np.empty(len(mesh.loop_triangles), dtype=np.uint32)
+    mesh.loop_triangles.foreach_get("material_index", mat_indices)  # materials, e.g.: [0, 1, 0, 1, 2, 1, ...]
+    index_array = np.arange(num_corners, dtype=np.int32)  # -> [0, 1, 2, 3, 4, 5, ...]
+    index_array = index_array.reshape((-1, 3))  # -> [[0, 1, 2], [3, 4, 5], ...]
 
-  print(" - Mesh", (time.process_time() - tDes) * 1000)
+    # remove faces based on 'tri_hidden' (0=visible, 1=hidden)
+    index_array = index_array[tri_hidden == 0]
+    mat_indices = mat_indices[tri_hidden == 0]
 
-  return MeshBuffers(positions, colors, uvs, normals, index_array, index_offsets, None, None, None, None)
+    index_array = index_array[np.argsort(mat_indices)]  # sort index_array by value in use_flat (aka material-index)
+    index_offsets = np.bincount(
+        mat_indices, minlength=mat_count
+    )  # now get counts of each material, e.g.: [1, 2] where index is material-index
+    index_offsets = np.insert(index_offsets, 0, 0)  # prepend 0 to turn counts into offsets
+    index_offsets = np.cumsum(index_offsets)  # converted into accumulated offset
+
+    print(" - Mesh", (time.process_time() - tDes) * 1000)
+
+    return MeshBuffers(positions, colors, uvs, normals, index_array, index_offsets, None, None, None, None)

--- a/mesh/mesh.py
+++ b/mesh/mesh.py
@@ -18,8 +18,7 @@ class MeshBuffers:
     indices: np.ndarray # global index array, sorted by material
     index_offsets: np.ndarray # offsets for each material in the index array
   # render data:
-    batch: gpu.types.GPUBatch
-    mat_data: list[np.ndarray]
+    batch: list[gpu.types.GPUBatch]|gpu.types.GPUBatch
     ubo_mat_data: list[gpu.types.GPUUniformBuf]
     materials: list[F64Material] = None
     mesh_name: str = "" # multiple obj. can share the same mesh, store to allow deletion by name
@@ -28,16 +27,18 @@ class MeshBuffers:
 # Note that this can be a slow process, so it should be cached externally
 # This will only handle mesh data itself, materials are not read out here
 def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
+  from fast64_internal.f3d.f3d_writer import getColorLayer
+
   tDes = time.process_time()
   mesh.calc_loop_triangles()
 
   # Here we want to transform all attributes into un-indexed arrays of per-vertex data
   # Position + normals are stored per vertex (indexed), colors and uvs are stored per face-corner
   # All need to be normalized to the same length
-  
-  color_layer = mesh.color_attributes.get("Col")
-  alpha_layer = mesh.color_attributes.get("Alpha")
-  uv_layer = mesh.uv_layers.active.data if mesh.uv_layers.active else None
+
+  uv_layer = mesh.uv_layers.get("UVMap", mesh.uv_layers.active)
+  if uv_layer is not None:
+    uv_layer = uv_layer.data
 
   num_corners = len(mesh.loop_triangles) * 3
   # print("Faces: ", num_corners, color_layer)
@@ -56,29 +57,47 @@ def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
   positions = tmp_vec3[indices]
 
   # read normals (these contain pre-calculated normals handling  flat, smooth, custom split normals)
-  corner_norm = np.empty((len(mesh.corner_normals), 3), dtype=np.float32)
-  mesh.corner_normals.foreach_get('vector', corner_norm.ravel())
+  if bpy.app.version < (4, 0, 0):
+      mesh.calc_normals_split()
+      corner_norm = np.empty((len(mesh.loops), 3), dtype=np.float32)
+      mesh.loops.foreach_get('normal', corner_norm.ravel())
+  else:
+    corner_norm = np.empty((len(mesh.corner_normals), 3), dtype=np.float32)
+    mesh.corner_normals.foreach_get('vector', corner_norm.ravel())
 
   mesh.loop_triangles.foreach_get('loops', indices)
   normals = corner_norm[indices]
   
-  if uv_layer: 
-    uv_layer.foreach_get('uv', uvs.ravel())
-    uvs = uvs[indices]
+  if uv_layer is not None: 
+    corner_uvs = np.empty((len(uv_layer), 2), dtype=np.float32)
+    uv_layer.foreach_get('uv', corner_uvs.ravel())
+    uvs = corner_uvs[indices]
   else:
     uvs.fill(0.0)
 
-  if color_layer:
-    colors_tmp = np.empty((len(color_layer.data), 4), dtype=np.float32)
-    color_layer.data.foreach_get('color_srgb', colors_tmp.ravel())
+  # HACK: color and alpha layer must be read after the other is used, old blends break otherwise?
+  color_layer = getColorLayer(mesh, layer="Col")
+  if color_layer is not None:
+    colors_tmp = np.empty((len(color_layer), 4), dtype=np.float32)
+    if bpy.app.version > (3, 2, 0):
+      color_layer.foreach_get('color_srgb', colors_tmp.ravel())
+    else: # vectorized linear -> sRGB conversion
+      color_layer.foreach_get('color', colors_tmp.ravel())
+      mask = colors_tmp > 0.0031308
+      colors_tmp[mask] = 1.055 * (np.power(colors_tmp[mask], (1.0 / 2.4))) - 0.055
+      colors_tmp[~mask] *= 12.92
     colors = colors_tmp[indices]
-
-    if alpha_layer:
-      alpha_layer.data.foreach_get('color', colors_tmp.ravel())
-      colors[:, 3] = colors_tmp[indices, 0]
 
   else:
     colors.fill(1.0)
+
+  alpha_layer = getColorLayer(mesh, layer="Alpha")
+  if alpha_layer is not None:
+    alpha_tmp = np.empty((len(alpha_layer), 4), dtype=np.float32)
+    alpha_layer.foreach_get('color', alpha_tmp.ravel())
+    colors[:, 3] = alpha_tmp[indices, 0] # TODO: use blender lum convert to match exports?
+  else:
+    colors[:, 3] = 1.0
 
   # create map of hidden polygons (we need to map that to triangles)
   poly_hidden = np.empty(len(mesh.polygons), dtype=np.int32)
@@ -92,7 +111,7 @@ def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
   # this is done to do a cheap split by material
   mat_count = len(mesh.materials)
 
-  mat_indices = np.empty(len(mesh.loop_triangles), dtype=np.int8)
+  mat_indices = np.empty(len(mesh.loop_triangles), dtype=np.uint32)
   mesh.loop_triangles.foreach_get('material_index', mat_indices) # materials, e.g.: [0, 1, 0, 1, 2, 1, ...]
   index_array = np.arange(num_corners, dtype=np.int32) # -> [0, 1, 2, 3, 4, 5, ...]
   index_array = index_array.reshape((-1, 3))           # -> [[0, 1, 2], [3, 4, 5], ...]
@@ -104,8 +123,8 @@ def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
   index_array = index_array[np.argsort(mat_indices)] # sort index_array by value in use_flat (aka material-index)
   index_offsets = np.bincount(mat_indices, minlength=mat_count)    # now get counts of each material, e.g.: [1, 2] where index is material-index
   index_offsets = np.insert(index_offsets, 0, 0)  # prepend 0 to turn counts into offsets
-  index_offsets = np.cumsum(index_offsets) * 3    # converted into accumulated offset / mul. by 3 for triangles
+  index_offsets = np.cumsum(index_offsets)   # converted into accumulated offset
 
   print(" - Mesh", (time.process_time() - tDes) * 1000)
 
-  return MeshBuffers(positions, colors, uvs, normals, index_array, index_offsets, None, None, None, None, None)
+  return MeshBuffers(positions, colors, uvs, normals, index_array, index_offsets, None, None, None, None)

--- a/oot.py
+++ b/oot.py
@@ -1,0 +1,110 @@
+import copy
+from typing import NamedTuple
+
+import bpy
+import mathutils
+
+from .material.parser import parse_f3d_rendermode_preset, F64RenderState
+from .common import ObjRenderInfo, draw_f64_obj, collect_obj_info, get_scene_render_state
+from .properties import F64RenderSettings
+from .globals import F64_GLOBALS
+
+class RoomRenderInfo(NamedTuple):
+  render_state: F64RenderState
+  name: str
+  def __hash__(self):
+    return hash(self.name)
+
+def get_oot_room_childrens(scene: bpy.types.Scene):
+  if F64_GLOBALS.oot_room_lookup is not None:
+    return F64_GLOBALS.oot_room_lookup
+
+  oot_room_lookup = {}
+  render_state = get_scene_render_state(scene)
+  scene_objs: list[bpy.types.Object] = []
+  room_objs: list[bpy.types.Object] = []
+
+  def get_room_children(obj: bpy.types.Object, name: str):
+    for child in sorted(obj.children, key=lambda item: item.name): 
+      if child not in room_objs:
+        oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
+        get_room_children(child, name)
+      else:
+        get_room_children(child, child.name)
+
+  def get_scene_children(obj: bpy.types.Object, name: str):
+    for child in sorted(obj.children, key=lambda item: item.name): 
+      if child in room_objs:
+        get_room_children(child, child.name)
+      else:
+        oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
+        get_scene_children(child, name)
+
+  for obj in bpy.data.objects:
+    if obj.type == "EMPTY":
+      if obj.ootEmptyType == "Scene": scene_objs.append(obj)
+      if obj.ootEmptyType == "Room": room_objs.append(obj)
+
+  for scene_obj in scene_objs:
+    get_scene_children(scene_obj, scene_obj.name)
+
+  fake_room = RoomRenderInfo(render_state, None)
+  for obj in bpy.data.objects:
+    if obj.name not in oot_room_lookup:
+      oot_room_lookup[obj.name] = fake_room
+
+  F64_GLOBALS.oot_room_lookup = oot_room_lookup
+  return oot_room_lookup
+
+# TODO if porting to fast64, reuse existing default layer dict
+DEFAULT_LAYERS = {
+  "Opaque": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"), 
+  "Transparent": ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"), 
+  "Overlay": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"),}
+
+def draw_oot_scene(render_engine: "Fast64RenderEngine", depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool):
+  f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
+
+  layer_rendermodes = {} # TODO: should this be cached globally?
+  world = depsgraph.scene.world
+  for layer, (cycle1, cycle2) in DEFAULT_LAYERS.items():
+    if world:
+      defaults = world.ootDefaultRenderModes
+      cycle1, cycle2 = (getattr(defaults, f"{layer.lower()}Cycle{cycle}") for cycle in (1, 2))
+    rm_state = F64RenderState()
+    rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
+    rm_state.save_cache()
+    layer_rendermodes[layer] = rm_state
+  
+  ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
+  specific_room = f64render_rs.oot_specific_room.name if f64render_rs.oot_specific_room else None
+  room_lookup = get_oot_room_childrens(depsgraph.scene)
+  layer_queue: dict[str, dict[RoomRenderInfo, dict[str, ObjRenderInfo]]] = {}
+
+  for obj in depsgraph.objects:
+    obj_name = obj.name
+    room = room_lookup[obj_name]
+    if (ignore and obj.ignore_render) or (collision and obj.ignore_collision) or (specific_room and room.name != specific_room):
+      continue
+    obj_info = collect_obj_info(render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set)
+    if obj_info is None:
+      continue
+  
+    for mat_info in obj_info.mats:
+      mat = mat_info[2]
+      room_queue = layer_queue.setdefault(mat.layer or "Opaque", {}) # if layer has no room queue, create it
+      obj_queue = room_queue.setdefault(room, {}) # if current room has no obj queue in this layer, create it
+      if obj_name not in obj_queue: # if obj not already present in the layer's obj queue, create a shallow copy
+        obj_info = obj_queue[obj_name] = copy.copy(obj_info)
+        obj_info.mats = []
+      obj_queue[obj_name].mats.append(mat_info)
+
+  for layer in ("Opaque", "Transparent", "Overlay"):
+    room_queue = layer_queue.get(layer)
+    if room_queue is None: continue
+    for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name): # sort by layer
+      render_state = room.render_state.copy()
+      render_state.set_values_from_cache(layer_rendermodes.get(layer, layer_rendermodes["Opaque"]))
+      for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])): # sort by obj name
+        draw_f64_obj(render_engine, render_state, obj_queue[info])
+

--- a/oot.py
+++ b/oot.py
@@ -9,102 +9,124 @@ from .common import ObjRenderInfo, draw_f64_obj, collect_obj_info, get_scene_ren
 from .properties import F64RenderSettings
 from .globals import F64_GLOBALS
 
+
 class RoomRenderInfo(NamedTuple):
-  render_state: F64RenderState
-  name: str
-  def __hash__(self):
-    return hash(self.name)
+    render_state: F64RenderState
+    name: str
+
+    def __hash__(self):
+        return hash(self.name)
+
 
 def get_oot_room_childrens(scene: bpy.types.Scene):
-  if F64_GLOBALS.oot_room_lookup is not None:
-    return F64_GLOBALS.oot_room_lookup
+    if F64_GLOBALS.oot_room_lookup is not None:
+        return F64_GLOBALS.oot_room_lookup
 
-  oot_room_lookup = {}
-  render_state = get_scene_render_state(scene)
-  scene_objs: list[bpy.types.Object] = []
-  room_objs: list[bpy.types.Object] = []
+    oot_room_lookup = {}
+    render_state = get_scene_render_state(scene)
+    scene_objs: list[bpy.types.Object] = []
+    room_objs: list[bpy.types.Object] = []
 
-  def get_room_children(obj: bpy.types.Object, name: str):
-    for child in sorted(obj.children, key=lambda item: item.name): 
-      if child not in room_objs:
-        oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
-        get_room_children(child, name)
-      else:
-        get_room_children(child, child.name)
+    def get_room_children(obj: bpy.types.Object, name: str):
+        for child in sorted(obj.children, key=lambda item: item.name):
+            if child not in room_objs:
+                oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
+                get_room_children(child, name)
+            else:
+                get_room_children(child, child.name)
 
-  def get_scene_children(obj: bpy.types.Object, name: str):
-    for child in sorted(obj.children, key=lambda item: item.name): 
-      if child in room_objs:
-        get_room_children(child, child.name)
-      else:
-        oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
-        get_scene_children(child, name)
+    def get_scene_children(obj: bpy.types.Object, name: str):
+        for child in sorted(obj.children, key=lambda item: item.name):
+            if child in room_objs:
+                get_room_children(child, child.name)
+            else:
+                oot_room_lookup[child.name] = RoomRenderInfo(render_state, name)
+                get_scene_children(child, name)
 
-  for obj in bpy.data.objects:
-    if obj.type == "EMPTY":
-      if obj.ootEmptyType == "Scene": scene_objs.append(obj)
-      if obj.ootEmptyType == "Room": room_objs.append(obj)
+    for obj in bpy.data.objects:
+        if obj.type == "EMPTY":
+            if obj.ootEmptyType == "Scene":
+                scene_objs.append(obj)
+            if obj.ootEmptyType == "Room":
+                room_objs.append(obj)
 
-  for scene_obj in scene_objs:
-    get_scene_children(scene_obj, scene_obj.name)
+    for scene_obj in scene_objs:
+        get_scene_children(scene_obj, scene_obj.name)
 
-  fake_room = RoomRenderInfo(render_state, None)
-  for obj in bpy.data.objects:
-    if obj.name not in oot_room_lookup:
-      oot_room_lookup[obj.name] = fake_room
+    fake_room = RoomRenderInfo(render_state, None)
+    for obj in bpy.data.objects:
+        if obj.name not in oot_room_lookup:
+            oot_room_lookup[obj.name] = fake_room
 
-  F64_GLOBALS.oot_room_lookup = oot_room_lookup
-  return oot_room_lookup
+    F64_GLOBALS.oot_room_lookup = oot_room_lookup
+    return oot_room_lookup
+
 
 # TODO if porting to fast64, reuse existing default layer dict
 DEFAULT_LAYERS = {
-  "Opaque": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"), 
-  "Transparent": ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"), 
-  "Overlay": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"),}
+    "Opaque": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"),
+    "Transparent": ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"),
+    "Overlay": ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"),
+}
 
-def draw_oot_scene(render_engine: "Fast64RenderEngine", depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool):
-  f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
 
-  layer_rendermodes = {} # TODO: should this be cached globally?
-  world = depsgraph.scene.world
-  for layer, (cycle1, cycle2) in DEFAULT_LAYERS.items():
-    if world:
-      defaults = world.ootDefaultRenderModes
-      cycle1, cycle2 = (getattr(defaults, f"{layer.lower()}Cycle{cycle}") for cycle in (1, 2))
-    rm_state = F64RenderState()
-    rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
-    rm_state.save_cache()
-    layer_rendermodes[layer] = rm_state
-  
-  ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
-  specific_room = f64render_rs.oot_specific_room.name if f64render_rs.oot_specific_room else None
-  room_lookup = get_oot_room_childrens(depsgraph.scene)
-  layer_queue: dict[str, dict[RoomRenderInfo, dict[str, ObjRenderInfo]]] = {}
+def draw_oot_scene(
+    render_engine: "Fast64RenderEngine",
+    depsgraph: bpy.types.Depsgraph,
+    hidden_objs_names: set[str],
+    space_view_3d: bpy.types.SpaceView3D,
+    projection_matrix: mathutils.Matrix,
+    view_matrix: mathutils.Matrix,
+    always_set: bool,
+):
+    f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
 
-  for obj in depsgraph.objects:
-    obj_name = obj.name
-    room = room_lookup[obj_name]
-    if (ignore and obj.ignore_render) or (collision and obj.ignore_collision) or (specific_room and room.name != specific_room):
-      continue
-    obj_info = collect_obj_info(render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set)
-    if obj_info is None:
-      continue
-  
-    for mat_info in obj_info.mats:
-      mat = mat_info[2]
-      room_queue = layer_queue.setdefault(mat.layer or "Opaque", {}) # if layer has no room queue, create it
-      obj_queue = room_queue.setdefault(room, {}) # if current room has no obj queue in this layer, create it
-      if obj_name not in obj_queue: # if obj not already present in the layer's obj queue, create a shallow copy
-        obj_info = obj_queue[obj_name] = copy.copy(obj_info)
-        obj_info.mats = []
-      obj_queue[obj_name].mats.append(mat_info)
+    layer_rendermodes = {}  # TODO: should this be cached globally?
+    world = depsgraph.scene.world
+    for layer, (cycle1, cycle2) in DEFAULT_LAYERS.items():
+        if world:
+            defaults = world.ootDefaultRenderModes
+            cycle1, cycle2 = (getattr(defaults, f"{layer.lower()}Cycle{cycle}") for cycle in (1, 2))
+        rm_state = F64RenderState()
+        rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
+        rm_state.save_cache()
+        layer_rendermodes[layer] = rm_state
 
-  for layer in ("Opaque", "Transparent", "Overlay"):
-    room_queue = layer_queue.get(layer)
-    if room_queue is None: continue
-    for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name): # sort by layer
-      render_state = room.render_state.copy()
-      render_state.set_values_from_cache(layer_rendermodes.get(layer, layer_rendermodes["Opaque"]))
-      for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])): # sort by obj name
-        draw_f64_obj(render_engine, render_state, obj_queue[info])
+    ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
+    specific_room = f64render_rs.oot_specific_room.name if f64render_rs.oot_specific_room else None
+    room_lookup = get_oot_room_childrens(depsgraph.scene)
+    layer_queue: dict[str, dict[RoomRenderInfo, dict[str, ObjRenderInfo]]] = {}
 
+    for obj in depsgraph.objects:
+        obj_name = obj.name
+        room = room_lookup[obj_name]
+        if (
+            (ignore and obj.ignore_render)
+            or (collision and obj.ignore_collision)
+            or (specific_room and room.name != specific_room)
+        ):
+            continue
+        obj_info = collect_obj_info(
+            render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set
+        )
+        if obj_info is None:
+            continue
+
+        for mat_info in obj_info.mats:
+            mat = mat_info[2]
+            room_queue = layer_queue.setdefault(mat.layer or "Opaque", {})  # if layer has no room queue, create it
+            obj_queue = room_queue.setdefault(room, {})  # if current room has no obj queue in this layer, create it
+            if obj_name not in obj_queue:  # if obj not already present in the layer's obj queue, create a shallow copy
+                obj_info = obj_queue[obj_name] = copy.copy(obj_info)
+                obj_info.mats = []
+            obj_queue[obj_name].mats.append(mat_info)
+
+    for layer in ("Opaque", "Transparent", "Overlay"):
+        room_queue = layer_queue.get(layer)
+        if room_queue is None:
+            continue
+        for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name):  # sort by layer
+            render_state = room.render_state.copy()
+            render_state.set_values_from_cache(layer_rendermodes.get(layer, layer_rendermodes["Opaque"]))
+            for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])):  # sort by obj name
+                draw_f64_obj(render_engine, render_state, obj_queue[info])

--- a/properties.py
+++ b/properties.py
@@ -130,7 +130,7 @@ def update_all_materials(_scene, _context):
 
 
 def rebuild_shaders(_scene, _context):
-    F64_GLOBALS.rebuid_shaders = True
+    F64_GLOBALS.rebuild_shaders = True
 
 
 class F64RenderSettings(bpy.types.PropertyGroup):

--- a/properties.py
+++ b/properties.py
@@ -6,253 +6,270 @@ from .globals import F64_GLOBALS
 # TODO: Some things are from fast64 but can´t be imported at runtime
 
 enumTexFormat = [
-  ("I4", "Intensity 4-bit", "Intensity 4-bit"),
-  ("I8", "Intensity 8-bit", "Intensity 8-bit"),
-  ("IA4", "Intensity Alpha 4-bit", "Intensity Alpha 4-bit"),
-  ("IA8", "Intensity Alpha 8-bit", "Intensity Alpha 8-bit"),
-  ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
-  ("CI4", "Color Index 4-bit", "Color Index 4-bit"),
-  ("CI8", "Color Index 8-bit", "Color Index 8-bit"),
-  ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
-  ("RGBA32", "RGBA 32-bit", "RGBA 32-bit"),
-  # ('YUV16','YUV 16-bit', 'YUV 16-bit'),
+    ("I4", "Intensity 4-bit", "Intensity 4-bit"),
+    ("I8", "Intensity 8-bit", "Intensity 8-bit"),
+    ("IA4", "Intensity Alpha 4-bit", "Intensity Alpha 4-bit"),
+    ("IA8", "Intensity Alpha 8-bit", "Intensity Alpha 8-bit"),
+    ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
+    ("CI4", "Color Index 4-bit", "Color Index 4-bit"),
+    ("CI8", "Color Index 8-bit", "Color Index 8-bit"),
+    ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
+    ("RGBA32", "RGBA 32-bit", "RGBA 32-bit"),
+    # ('YUV16','YUV 16-bit', 'YUV 16-bit'),
 ]
 
 enumCIFormat = [
-  ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
-  ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
+    ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
+    ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
 ]
 
+
 def simplified_tex_update(self, context):
-  from fast64_internal.f3d.f3d_material import setAutoProp
-  tex_size = self.get_tex_size()
-  if self.tex is not None and self.autoprop:
-    setAutoProp(self.S, tex_size[0])
-    setAutoProp(self.T, tex_size[1])
+    from fast64_internal.f3d.f3d_material import setAutoProp
+
+    tex_size = self.get_tex_size()
+    if self.tex is not None and self.autoprop:
+        setAutoProp(self.S, tex_size[0])
+        setAutoProp(self.T, tex_size[1])
+
 
 class TextureFieldProperty(PropertyGroup):
-  clamp: bpy.props.BoolProperty(name="Clamp")
-  mirror: bpy.props.BoolProperty(name="Mirror")
-  low: bpy.props.FloatProperty(
-    name="Low",
-    min=0,
-    max=1023.75,
-  )
-  high: bpy.props.FloatProperty(
-    name="High",
-    min=0,
-    max=1023.75,
-  )
-  mask: bpy.props.IntProperty(
-    name="Mask",
-    min=0,
-    max=15,
-    default=5,
-  )
-  shift: bpy.props.IntProperty(
-    name="Shift",
-    min=-5,
-    max=10,
-  )
+    clamp: bpy.props.BoolProperty(name="Clamp")
+    mirror: bpy.props.BoolProperty(name="Mirror")
+    low: bpy.props.FloatProperty(
+        name="Low",
+        min=0,
+        max=1023.75,
+    )
+    high: bpy.props.FloatProperty(
+        name="High",
+        min=0,
+        max=1023.75,
+    )
+    mask: bpy.props.IntProperty(
+        name="Mask",
+        min=0,
+        max=15,
+        default=5,
+    )
+    shift: bpy.props.IntProperty(
+        name="Shift",
+        min=-5,
+        max=10,
+    )
 
 
 class TextureProperty(PropertyGroup):
-  tex: bpy.props.PointerProperty(
-    type=Image,
-    name="Texture",
-    update=simplified_tex_update,
-  )
+    tex: bpy.props.PointerProperty(
+        type=Image,
+        name="Texture",
+        update=simplified_tex_update,
+    )
 
-  tex_format: bpy.props.EnumProperty(
-    name="Format",
-    items=enumTexFormat,
-    default="RGBA16",
-    update=simplified_tex_update,
-  )
-  ci_format: bpy.props.EnumProperty(
-    name="CI Format",
-    items=enumCIFormat,
-    default="RGBA16",
-    update=simplified_tex_update,
-  )
-  S: bpy.props.PointerProperty(type=TextureFieldProperty)
-  T: bpy.props.PointerProperty(type=TextureFieldProperty)
+    tex_format: bpy.props.EnumProperty(
+        name="Format",
+        items=enumTexFormat,
+        default="RGBA16",
+        update=simplified_tex_update,
+    )
+    ci_format: bpy.props.EnumProperty(
+        name="CI Format",
+        items=enumCIFormat,
+        default="RGBA16",
+        update=simplified_tex_update,
+    )
+    S: bpy.props.PointerProperty(type=TextureFieldProperty)
+    T: bpy.props.PointerProperty(type=TextureFieldProperty)
 
-  menu: bpy.props.BoolProperty()
-  autoprop: bpy.props.BoolProperty(
-    name="Autoprop",
-    default=True,
-    update=simplified_tex_update,
-  )
+    menu: bpy.props.BoolProperty()
+    autoprop: bpy.props.BoolProperty(
+        name="Autoprop",
+        default=True,
+        update=simplified_tex_update,
+    )
 
-  def get_tex_size(self) -> list[int]:
-    if self.tex:
-      return self.tex.size
-    return [0, 0]
+    def get_tex_size(self) -> list[int]:
+        if self.tex:
+            return self.tex.size
+        return [0, 0]
 
-  def draw_default_ui(self, layout: bpy.types.UILayout, index: int):
-    def small_split(layout, prop: str, name: str):
-      split = layout.split(factor=0.25)
-      split.label(text=name)
-      split.prop(self, prop, text="")
-    def s_t(layout, name: str):
-      split = layout.split(factor=0.25)
-      split.label(text=name)
-      row = split.row()
-      row.prop(self.S, name.lower(), text="S")
-      row.prop(self.T, name.lower(), text="T")
-    col = layout.column()
-    row = col.row()
-    row.alignment = "LEFT"
-    row.prop(self, "menu", text="Texture " + str(index), icon="TRIA_DOWN" if self.menu else "TRIA_RIGHT")
-    if self.menu:
-      col.template_ID(self, "tex", new="image.new", open="image.open")
-      small_split(col, "tex_format", "Format")
-      if self.tex_format.startswith("CI"):
-        small_split(col, "ci_format", "")
-      s_t(col, "Clamp")
-      s_t(col, "Mirror")
-      col.prop(self, "autoprop", text="Auto Properties")
-      if not self.autoprop:
-        s_t(col, "Low")
-        s_t(col, "High")
-        s_t(col, "Mask")
-        s_t(col, "Shift")
+    def draw_default_ui(self, layout: bpy.types.UILayout, index: int):
+        def small_split(layout, prop: str, name: str):
+            split = layout.split(factor=0.25)
+            split.label(text=name)
+            split.prop(self, prop, text="")
+
+        def s_t(layout, name: str):
+            split = layout.split(factor=0.25)
+            split.label(text=name)
+            row = split.row()
+            row.prop(self.S, name.lower(), text="S")
+            row.prop(self.T, name.lower(), text="T")
+
+        col = layout.column()
+        row = col.row()
+        row.alignment = "LEFT"
+        row.prop(self, "menu", text="Texture " + str(index), icon="TRIA_DOWN" if self.menu else "TRIA_RIGHT")
+        if self.menu:
+            col.template_ID(self, "tex", new="image.new", open="image.open")
+            small_split(col, "tex_format", "Format")
+            if self.tex_format.startswith("CI"):
+                small_split(col, "ci_format", "")
+            s_t(col, "Clamp")
+            s_t(col, "Mirror")
+            col.prop(self, "autoprop", text="Auto Properties")
+            if not self.autoprop:
+                s_t(col, "Low")
+                s_t(col, "High")
+                s_t(col, "Mask")
+                s_t(col, "Shift")
+
 
 def update_all_materials(_scene, _context):
-  F64_GLOBALS.materials_cache = {}
+    F64_GLOBALS.materials_cache = {}
+
 
 def rebuild_shaders(_scene, _context):
-  F64_GLOBALS.rebuid_shaders = True
+    F64_GLOBALS.rebuid_shaders = True
+
 
 class F64RenderSettings(bpy.types.PropertyGroup):
-  use_atomic_rendering: bpy.props.BoolProperty(
-    name="Use Atomic Rendering",
-    default=True,
-    description="Atomic rendering will draw to a depth and color buffer seperately, which allows for proper blender and decal emulation.\n"
-    "This may cause artifacts if your GPU does not support the interlock extension",
-    update=rebuild_shaders
-  )
-  sources_tab: bpy.props.BoolProperty(name="Default Sources")
-  default_prim_color: bpy.props.FloatVectorProperty(
-    description="Primitive Color",
-    default=(1, 1, 1, 1),
-    subtype="COLOR",
-    size=4,
-    min=0,
-    max=1
-  )
-  default_lod_frac: bpy.props.FloatProperty(
-    description="Prim LOD Frac",
-    min=0,
-    max=1,
-    step=1
-  )
-  default_lod_min: bpy.props.FloatProperty(
-    description="Min LOD Ratio",
-    min=0,
-    max=1,
-    step=1
-  )
-  default_env_color: bpy.props.FloatVectorProperty(
-    description="Enviroment Color",
-    default=(0.5, 0.5, 0.5, 0.5),
-    subtype="COLOR",
-    size=4,
-    min=0,
-    max=1
-  )
+    use_atomic_rendering: bpy.props.BoolProperty(
+        name="Use Atomic Rendering",
+        default=True,
+        description="Atomic rendering will draw to a depth and color buffer seperately, which allows for proper blender and decal emulation.\n"
+        "This may cause artifacts if your GPU does not support the interlock extension",
+        update=rebuild_shaders,
+    )
+    sources_tab: bpy.props.BoolProperty(name="Default Sources")
+    default_prim_color: bpy.props.FloatVectorProperty(
+        description="Primitive Color",
+        default=(1, 1, 1, 1),
+        subtype="COLOR",
+        size=4,
+        min=0,
+        max=1,
+    )
+    default_lod_frac: bpy.props.FloatProperty(
+        description="Prim LOD Frac",
+        min=0,
+        max=1,
+        step=1,
+    )
+    default_lod_min: bpy.props.FloatProperty(
+        description="Min LOD Ratio",
+        min=0,
+        max=1,
+        step=1,
+    )
+    default_env_color: bpy.props.FloatVectorProperty(
+        description="Enviroment Color",
+        default=(0.5, 0.5, 0.5, 0.5),
+        subtype="COLOR",
+        size=4,
+        min=0,
+        max=1,
+    )
 
-  chroma_tab: bpy.props.BoolProperty(name="Chroma Key")
-  default_key_center: bpy.props.FloatVectorProperty(
-    description="Key Center",
-    subtype="COLOR",
-    size=4,
-    min=0,
-    max=1,
-    default=(1, 1, 1, 1),  )
-  default_key_scale: bpy.props.FloatVectorProperty(
-    description="Key Scale",
-    min=0,
-    max=1,
-    step=1,
-  )
-  default_key_width: bpy.props.FloatVectorProperty(
-    description="Key Width",
-    min=0,
-    max=16,
-  )
+    chroma_tab: bpy.props.BoolProperty(name="Chroma Key")
+    default_key_center: bpy.props.FloatVectorProperty(
+        description="Key Center",
+        subtype="COLOR",
+        size=4,
+        min=0,
+        max=1,
+        default=(1, 1, 1, 1),
+    )
+    default_key_scale: bpy.props.FloatVectorProperty(
+        description="Key Scale",
+        min=0,
+        max=1,
+        step=1,
+    )
+    default_key_width: bpy.props.FloatVectorProperty(
+        description="Key Width",
+        min=0,
+        max=16,
+    )
 
-  convert_tab: bpy.props.BoolProperty(name="YUV Convert")
-  default_convert: bpy.props.FloatVectorProperty(
-    description="YUV Convert",
-    size=6,
-    min=-1,
-    max=1,
-    step=1,
-    default=(175 / 255, -43 / 255, -89 / 255, 222 / 255, 114 / 255, 42 / 255)
-  )
+    convert_tab: bpy.props.BoolProperty(name="YUV Convert")
+    default_convert: bpy.props.FloatVectorProperty(
+        description="YUV Convert",
+        size=6,
+        min=-1,
+        max=1,
+        step=1,
+        default=(175 / 255, -43 / 255, -89 / 255, 222 / 255, 114 / 255, 42 / 255),
+    )
 
-  texture_tab: bpy.props.BoolProperty(name="Textures")
-  default_tex0: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex1: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex2: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex3: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex4: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex5: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex6: bpy.props.PointerProperty(type=TextureProperty)
-  default_tex7: bpy.props.PointerProperty(type=TextureProperty)
-  always_set: bpy.props.BoolProperty(name="Ignore \"Set (Source)\"", update=update_all_materials)
+    texture_tab: bpy.props.BoolProperty(name="Textures")
+    default_tex0: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex1: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex2: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex3: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex4: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex5: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex6: bpy.props.PointerProperty(type=TextureProperty)
+    default_tex7: bpy.props.PointerProperty(type=TextureProperty)
+    always_set: bpy.props.BoolProperty(name='Ignore "Set (Source)"', update=update_all_materials)
 
-  render_type: bpy.props.EnumProperty(
-    items=[
-            ("DEFAULT", "Always Draw", "Always Draw"), 
-            ("IGNORE", "Respect \"Ignore Render\"", "Respect \"Ignore Render\""), 
-            ("COLLISION", "Only Collision", "Collision")
-    ],
-  )
-  sm64_specific_area: bpy.props.PointerProperty(type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root")
-  oot_specific_room: bpy.props.PointerProperty(type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.ootEmptyType == "Room")
+    render_type: bpy.props.EnumProperty(
+        items=[
+            ("DEFAULT", "Always Draw", "Always Draw"),
+            ("IGNORE", 'Respect "Ignore Render"', 'Respect "Ignore Render"'),
+            ("COLLISION", "Only Collision", "Collision"),
+        ],
+    )
+    sm64_specific_area: bpy.props.PointerProperty(
+        type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root"
+    )
+    oot_specific_room: bpy.props.PointerProperty(
+        type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.ootEmptyType == "Room"
+    )
 
-  def draw_props(self, layout: bpy.types.UILayout, gameEditorMode: str):
-    from fast64_internal.utility import prop_split, multilineLabel
-    layout = layout.column()
-    if gameEditorMode in {"SM64", "OOT"}:
-      prop_split(layout, self, "render_type", "Render Type")
-      if gameEditorMode == "SM64": prop_split(layout, self, "sm64_specific_area", "Specific Area")
-      if gameEditorMode == "OOT": prop_split(layout, self, "oot_specific_room", "Specific Room")
-      layout.separator()
+    def draw_props(self, layout: bpy.types.UILayout, gameEditorMode: str):
+        from fast64_internal.utility import prop_split, multilineLabel
 
-    if bpy.app.version >= (4, 1, 0):
-      layout.prop(self, "use_atomic_rendering")
-    layout.prop(self, "always_set")
-    layout.prop(self, "sources_tab", icon="TRIA_DOWN" if self.sources_tab else "TRIA_RIGHT")
-    if self.sources_tab:
-      sources_box = layout.box().column()
-      prop_split(sources_box, self, "default_prim_color", "Primitive")
-      prim_lod_row = sources_box.row()
-      prim_lod_row.prop(self, "default_lod_frac", text="Frac")
-      prim_lod_row.prop(self, "default_lod_min", text="Min")
-      prop_split(sources_box, self, "default_env_color", "Environment")
+        layout = layout.column()
+        if gameEditorMode in {"SM64", "OOT"}:
+            prop_split(layout, self, "render_type", "Render Type")
+            if gameEditorMode == "SM64":
+                prop_split(layout, self, "sm64_specific_area", "Specific Area")
+            if gameEditorMode == "OOT":
+                prop_split(layout, self, "oot_specific_room", "Specific Room")
+            layout.separator()
 
-      sources_box.prop(self, "chroma_tab", icon="TRIA_DOWN" if self.chroma_tab else "TRIA_RIGHT")
-      if self.chroma_tab:
-        prop_split(sources_box, self, "default_key_center", "Center")
-        prop_split(sources_box, self, "default_key_scale", "Scale")
-        prop_split(sources_box, self, "default_key_width", "Width")
-        if self.default_key_width[0] > 1 or self.default_key_width[1] > 1 or self.default_key_width[2] > 1:
-            multilineLabel(sources_box.box(), "Keying is disabled for\nchannels with width > 1.", icon="INFO")
-      
-      sources_box.prop(self, "convert_tab", icon="TRIA_DOWN" if self.convert_tab else "TRIA_RIGHT")
-      if self.convert_tab:
-        sources_box.prop(self, "default_convert", text="")
+        if bpy.app.version >= (4, 1, 0):
+            layout.prop(self, "use_atomic_rendering")
+        layout.prop(self, "always_set")
+        layout.prop(self, "sources_tab", icon="TRIA_DOWN" if self.sources_tab else "TRIA_RIGHT")
+        if self.sources_tab:
+            sources_box = layout.box().column()
+            prop_split(sources_box, self, "default_prim_color", "Primitive")
+            prim_lod_row = sources_box.row()
+            prim_lod_row.prop(self, "default_lod_frac", text="Frac")
+            prim_lod_row.prop(self, "default_lod_min", text="Min")
+            prop_split(sources_box, self, "default_env_color", "Environment")
 
-      sources_box.prop(self, "texture_tab", icon="TRIA_DOWN" if self.texture_tab else "TRIA_RIGHT")
-      if self.texture_tab:
-        texture_box = sources_box.box().column()
-        for i in range(8):
-          tex_prop = getattr(self, f"default_tex{i}")
-          tex_prop.draw_default_ui(texture_box, i)
+            sources_box.prop(self, "chroma_tab", icon="TRIA_DOWN" if self.chroma_tab else "TRIA_RIGHT")
+            if self.chroma_tab:
+                prop_split(sources_box, self, "default_key_center", "Center")
+                prop_split(sources_box, self, "default_key_scale", "Scale")
+                prop_split(sources_box, self, "default_key_width", "Width")
+                if self.default_key_width[0] > 1 or self.default_key_width[1] > 1 or self.default_key_width[2] > 1:
+                    multilineLabel(sources_box.box(), "Keying is disabled for\nchannels with width > 1.", icon="INFO")
+
+            sources_box.prop(self, "convert_tab", icon="TRIA_DOWN" if self.convert_tab else "TRIA_RIGHT")
+            if self.convert_tab:
+                sources_box.prop(self, "default_convert", text="")
+
+            sources_box.prop(self, "texture_tab", icon="TRIA_DOWN" if self.texture_tab else "TRIA_RIGHT")
+            if self.texture_tab:
+                texture_box = sources_box.box().column()
+                for i in range(8):
+                    tex_prop = getattr(self, f"default_tex{i}")
+                    tex_prop.draw_default_ui(texture_box, i)
+
 
 class F64RenderProperties(bpy.types.PropertyGroup):
-  render_settings: bpy.props.PointerProperty(type=F64RenderSettings)
+    render_settings: bpy.props.PointerProperty(type=F64RenderSettings)

--- a/properties.py
+++ b/properties.py
@@ -1,0 +1,258 @@
+import bpy
+from bpy.types import PropertyGroup, Image
+
+from .globals import F64_GLOBALS
+
+# TODO: Some things are from fast64 but can´t be imported at runtime
+
+enumTexFormat = [
+  ("I4", "Intensity 4-bit", "Intensity 4-bit"),
+  ("I8", "Intensity 8-bit", "Intensity 8-bit"),
+  ("IA4", "Intensity Alpha 4-bit", "Intensity Alpha 4-bit"),
+  ("IA8", "Intensity Alpha 8-bit", "Intensity Alpha 8-bit"),
+  ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
+  ("CI4", "Color Index 4-bit", "Color Index 4-bit"),
+  ("CI8", "Color Index 8-bit", "Color Index 8-bit"),
+  ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
+  ("RGBA32", "RGBA 32-bit", "RGBA 32-bit"),
+  # ('YUV16','YUV 16-bit', 'YUV 16-bit'),
+]
+
+enumCIFormat = [
+  ("RGBA16", "RGBA 16-bit", "RGBA 16-bit"),
+  ("IA16", "Intensity Alpha 16-bit", "Intensity Alpha 16-bit"),
+]
+
+def simplified_tex_update(self, context):
+  from fast64_internal.f3d.f3d_material import setAutoProp
+  tex_size = self.get_tex_size()
+  if self.tex is not None and self.autoprop:
+    setAutoProp(self.S, tex_size[0])
+    setAutoProp(self.T, tex_size[1])
+
+class TextureFieldProperty(PropertyGroup):
+  clamp: bpy.props.BoolProperty(name="Clamp")
+  mirror: bpy.props.BoolProperty(name="Mirror")
+  low: bpy.props.FloatProperty(
+    name="Low",
+    min=0,
+    max=1023.75,
+  )
+  high: bpy.props.FloatProperty(
+    name="High",
+    min=0,
+    max=1023.75,
+  )
+  mask: bpy.props.IntProperty(
+    name="Mask",
+    min=0,
+    max=15,
+    default=5,
+  )
+  shift: bpy.props.IntProperty(
+    name="Shift",
+    min=-5,
+    max=10,
+  )
+
+
+class TextureProperty(PropertyGroup):
+  tex: bpy.props.PointerProperty(
+    type=Image,
+    name="Texture",
+    update=simplified_tex_update,
+  )
+
+  tex_format: bpy.props.EnumProperty(
+    name="Format",
+    items=enumTexFormat,
+    default="RGBA16",
+    update=simplified_tex_update,
+  )
+  ci_format: bpy.props.EnumProperty(
+    name="CI Format",
+    items=enumCIFormat,
+    default="RGBA16",
+    update=simplified_tex_update,
+  )
+  S: bpy.props.PointerProperty(type=TextureFieldProperty)
+  T: bpy.props.PointerProperty(type=TextureFieldProperty)
+
+  menu: bpy.props.BoolProperty()
+  autoprop: bpy.props.BoolProperty(
+    name="Autoprop",
+    default=True,
+    update=simplified_tex_update,
+  )
+
+  def get_tex_size(self) -> list[int]:
+    if self.tex:
+      return self.tex.size
+    return [0, 0]
+
+  def draw_default_ui(self, layout: bpy.types.UILayout, index: int):
+    def small_split(layout, prop: str, name: str):
+      split = layout.split(factor=0.25)
+      split.label(text=name)
+      split.prop(self, prop, text="")
+    def s_t(layout, name: str):
+      split = layout.split(factor=0.25)
+      split.label(text=name)
+      row = split.row()
+      row.prop(self.S, name.lower(), text="S")
+      row.prop(self.T, name.lower(), text="T")
+    col = layout.column()
+    row = col.row()
+    row.alignment = "LEFT"
+    row.prop(self, "menu", text="Texture " + str(index), icon="TRIA_DOWN" if self.menu else "TRIA_RIGHT")
+    if self.menu:
+      col.template_ID(self, "tex", new="image.new", open="image.open")
+      small_split(col, "tex_format", "Format")
+      if self.tex_format.startswith("CI"):
+        small_split(col, "ci_format", "")
+      s_t(col, "Clamp")
+      s_t(col, "Mirror")
+      col.prop(self, "autoprop", text="Auto Properties")
+      if not self.autoprop:
+        s_t(col, "Low")
+        s_t(col, "High")
+        s_t(col, "Mask")
+        s_t(col, "Shift")
+
+def update_all_materials(_scene, _context):
+  F64_GLOBALS.materials_cache = {}
+
+def rebuild_shaders(_scene, _context):
+  F64_GLOBALS.rebuid_shaders = True
+
+class F64RenderSettings(bpy.types.PropertyGroup):
+  use_atomic_rendering: bpy.props.BoolProperty(
+    name="Use Atomic Rendering",
+    default=True,
+    description="Atomic rendering will draw to a depth and color buffer seperately, which allows for proper blender and decal emulation.\n"
+    "This may cause artifacts if your GPU does not support the interlock extension",
+    update=rebuild_shaders
+  )
+  sources_tab: bpy.props.BoolProperty(name="Default Sources")
+  default_prim_color: bpy.props.FloatVectorProperty(
+    description="Primitive Color",
+    default=(1, 1, 1, 1),
+    subtype="COLOR",
+    size=4,
+    min=0,
+    max=1
+  )
+  default_lod_frac: bpy.props.FloatProperty(
+    description="Prim LOD Frac",
+    min=0,
+    max=1,
+    step=1
+  )
+  default_lod_min: bpy.props.FloatProperty(
+    description="Min LOD Ratio",
+    min=0,
+    max=1,
+    step=1
+  )
+  default_env_color: bpy.props.FloatVectorProperty(
+    description="Enviroment Color",
+    default=(0.5, 0.5, 0.5, 0.5),
+    subtype="COLOR",
+    size=4,
+    min=0,
+    max=1
+  )
+
+  chroma_tab: bpy.props.BoolProperty(name="Chroma Key")
+  default_key_center: bpy.props.FloatVectorProperty(
+    description="Key Center",
+    subtype="COLOR",
+    size=4,
+    min=0,
+    max=1,
+    default=(1, 1, 1, 1),  )
+  default_key_scale: bpy.props.FloatVectorProperty(
+    description="Key Scale",
+    min=0,
+    max=1,
+    step=1,
+  )
+  default_key_width: bpy.props.FloatVectorProperty(
+    description="Key Width",
+    min=0,
+    max=16,
+  )
+
+  convert_tab: bpy.props.BoolProperty(name="YUV Convert")
+  default_convert: bpy.props.FloatVectorProperty(
+    description="YUV Convert",
+    size=6,
+    min=-1,
+    max=1,
+    step=1,
+    default=(175 / 255, -43 / 255, -89 / 255, 222 / 255, 114 / 255, 42 / 255)
+  )
+
+  texture_tab: bpy.props.BoolProperty(name="Textures")
+  default_tex0: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex1: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex2: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex3: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex4: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex5: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex6: bpy.props.PointerProperty(type=TextureProperty)
+  default_tex7: bpy.props.PointerProperty(type=TextureProperty)
+  always_set: bpy.props.BoolProperty(name="Ignore \"Set (Source)\"", update=update_all_materials)
+
+  render_type: bpy.props.EnumProperty(
+    items=[
+            ("DEFAULT", "Always Draw", "Always Draw"), 
+            ("IGNORE", "Respect \"Ignore Render\"", "Respect \"Ignore Render\""), 
+            ("COLLISION", "Only Collision", "Collision")
+    ],
+  )
+  sm64_specific_area: bpy.props.PointerProperty(type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root")
+  oot_specific_room: bpy.props.PointerProperty(type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.ootEmptyType == "Room")
+
+  def draw_props(self, layout: bpy.types.UILayout, gameEditorMode: str):
+    from fast64_internal.utility import prop_split, multilineLabel
+    layout = layout.column()
+    if gameEditorMode in {"SM64", "OOT"}:
+      prop_split(layout, self, "render_type", "Render Type")
+      if gameEditorMode == "SM64": prop_split(layout, self, "sm64_specific_area", "Specific Area")
+      if gameEditorMode == "OOT": prop_split(layout, self, "oot_specific_room", "Specific Room")
+      layout.separator()
+
+    if bpy.app.version >= (4, 1, 0):
+      layout.prop(self, "use_atomic_rendering")
+    layout.prop(self, "always_set")
+    layout.prop(self, "sources_tab", icon="TRIA_DOWN" if self.sources_tab else "TRIA_RIGHT")
+    if self.sources_tab:
+      sources_box = layout.box().column()
+      prop_split(sources_box, self, "default_prim_color", "Primitive")
+      prim_lod_row = sources_box.row()
+      prim_lod_row.prop(self, "default_lod_frac", text="Frac")
+      prim_lod_row.prop(self, "default_lod_min", text="Min")
+      prop_split(sources_box, self, "default_env_color", "Environment")
+
+      sources_box.prop(self, "chroma_tab", icon="TRIA_DOWN" if self.chroma_tab else "TRIA_RIGHT")
+      if self.chroma_tab:
+        prop_split(sources_box, self, "default_key_center", "Center")
+        prop_split(sources_box, self, "default_key_scale", "Scale")
+        prop_split(sources_box, self, "default_key_width", "Width")
+        if self.default_key_width[0] > 1 or self.default_key_width[1] > 1 or self.default_key_width[2] > 1:
+            multilineLabel(sources_box.box(), "Keying is disabled for\nchannels with width > 1.", icon="INFO")
+      
+      sources_box.prop(self, "convert_tab", icon="TRIA_DOWN" if self.convert_tab else "TRIA_RIGHT")
+      if self.convert_tab:
+        sources_box.prop(self, "default_convert", text="")
+
+      sources_box.prop(self, "texture_tab", icon="TRIA_DOWN" if self.texture_tab else "TRIA_RIGHT")
+      if self.texture_tab:
+        texture_box = sources_box.box().column()
+        for i in range(8):
+          tex_prop = getattr(self, f"default_tex{i}")
+          tex_prop.draw_default_ui(texture_box, i)
+
+class F64RenderProperties(bpy.types.PropertyGroup):
+  render_settings: bpy.props.PointerProperty(type=F64RenderSettings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+required-version = '23'
+line-length = 120
+target-version = [
+    'py310', # used by Blender 3.2
+]

--- a/renderer.py
+++ b/renderer.py
@@ -1,49 +1,38 @@
 import math
-import struct
+import pathlib
+import time
+
 import bpy
 import mathutils
 import gpu
+
 from .utils.addon import addon_set_fast64_path
-from .mesh.gpu_batch import batch_for_shader
-from .material.parser import F64Material, f64_material_parse, node_material_parse
-import pathlib
-import time
-import numpy as np
+from .material.parser import f64_parse_obj_light
+from .common import ObjRenderInfo, draw_f64_obj, get_scene_render_state, collect_obj_info
+from .properties import F64RenderProperties, F64RenderSettings
+from .globals import F64_GLOBALS
 
-from .mesh.mesh import MeshBuffers, mesh_to_buffers
-
-f64render_materials_dirty = True
-f64render_instance = None
-f64render_meshCache: dict[MeshBuffers] = {}
-current_ucode = None
+from .sm64 import draw_sm64_scene
+from .oot import draw_oot_scene
 
 # N64 is y-up, blender is z-up
 yup_to_zup = mathutils.Quaternion((1, 0, 0), math.radians(90.0)).to_matrix().to_4x4()
 
 MISSING_TEXTURE_COLOR = (0, 0, 0, 1)
 
-UNIFORM_BUFFER_STRUCT = struct.Struct(
-  "8i"              # blender
-  "16f"             # tile settings (mask/shift/low/high)
-  "16i"             # color-combiner settings
-  "i i i i"         # geoMode, other-low, other-high, flags
-  "4f 4f 3f f 3f f" # light (first light direction W is alpha-clip)
-  "4f 4f 4f"        # prim, env, ambient
-  "2f 2f"           # prim_lod, prim-depth
-  "8f 6f"           # ck center/scale, k0-k5,
-)
-
 def cache_del_by_mesh(mesh_name):
-  global f64render_meshCache
-  for key in list(f64render_meshCache.keys()):
-    if f64render_meshCache[key].mesh_name == mesh_name:
-      del f64render_meshCache[key]
+  for key in list(F64_GLOBALS.meshCache.keys()):
+    if F64_GLOBALS.meshCache[key].mesh_name == mesh_name:
+      del F64_GLOBALS.meshCache[key]
 
 def obj_has_f3d_materials(obj):
   for slot in obj.material_slots:
     if slot.material.is_f3d and slot.material.f3d_mat:
       return True
   return False
+
+def materials_set_light_direction(scene):
+  return not (scene.gameEditorMode == "SM64" and scene.fast64.sm64.matstack_fix)
 
 class Fast64RenderEngine(bpy.types.RenderEngine):
   bl_idname = "FAST64_RENDER_ENGINE"
@@ -55,9 +44,13 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     addon_set_fast64_path()
 
     self.shader = None
+    self.shader_2d = None
     self.shader_fallback = None
+    self.vbo_format = None
     self.draw_handler = None
-    self.last_ucode = None
+    self.use_atomic_rendering = True
+
+    self.last_used_textures: dict[int, gpu.types.GPUTexture] = {}
 
     self.time_count = 0
     self.time_total = 0
@@ -65,7 +58,10 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     self.depth_texture: gpu.types.GPUTexture = None
     self.color_texture: gpu.types.GPUTexture = None
     self.update_render_size(128, 128)
+
     bpy.app.handlers.depsgraph_update_post.append(Fast64RenderEngine.mesh_change_listener)
+    bpy.app.handlers.frame_change_post.append(Fast64RenderEngine.mesh_change_listener)
+    bpy.app.handlers.load_pre.append(Fast64RenderEngine.on_file_load)
 
     if "f64render_missing_texture" not in bpy.data.images:
       # Create a 1x1 image
@@ -75,84 +71,98 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     self.shader_interlock_support = 'GL_ARB_fragment_shader_interlock' in ext_list
     if not self.shader_interlock_support:
       print("\n\nWarning: GL_ARB_fragment_shader_interlock not supported!\n\n")
+    if bpy.app.version < (4, 1, 0):
+      print("\n\nWarning: Blender version too old! Expect limited blending emulation!\n\n")
+    self.draw_range_impl = bpy.app.version >= (3, 6, 0)
 
   def __del__(self):
-    if Fast64RenderEngine.mesh_change_listener in bpy.app.handlers.depsgraph_update_post:
-      bpy.app.handlers.depsgraph_update_post.remove(Fast64RenderEngine.mesh_change_listener)
-    pass
-  
+    def remove_handler(handler, func):
+      while func in handler:
+        handler.remove(func)
+    remove_handler(bpy.app.handlers.depsgraph_update_post, Fast64RenderEngine.mesh_change_listener)
+    remove_handler(bpy.app.handlers.frame_change_post, Fast64RenderEngine.mesh_change_listener)
+    remove_handler(bpy.app.handlers.load_pre, Fast64RenderEngine.on_file_load)
+
   def update_render_size(self, size_x, size_y):
     if not self.depth_texture or size_x != self.depth_texture.width or size_y != self.depth_texture.height:
       self.depth_texture = gpu.types.GPUTexture((size_x, size_y), format='R32I')
       self.color_texture = gpu.types.GPUTexture((size_x, size_y), format='R32UI')
 
-  def init_shader(self):
-    if not self.shader:
-      print("Compiling shader")
+  def init_shader(self, scene: bpy.types.Scene):
+    print("Compiling shader")
 
-      shaderPath = (pathlib.Path(__file__).parent / "shader").resolve()
-      shaderVert = ""
-      shaderFrag = ""
+    shaderPath = (pathlib.Path(__file__).parent / "shader").resolve()
+    shaderVert = ""
+    shaderFrag = ""
 
-      with open(shaderPath / "utils.glsl", "r", encoding="utf-8") as f:
-        shaderUtils = f.read()
-        shaderVert += shaderUtils
-        shaderFrag += shaderUtils
+    with open(shaderPath / "utils.glsl", "r", encoding="utf-8") as f:
+      shaderUtils = f.read()
+      shaderVert += shaderUtils
+      shaderFrag += shaderUtils
 
-      with open(shaderPath / "defines.glsl", "r", encoding="utf-8") as f:
-        shaderDef = f.read()
-        shaderVert += shaderDef
-        shaderFrag += shaderDef
+    with open(shaderPath / "defines.glsl", "r", encoding="utf-8") as f:
+      shaderDef = f.read()
+      shaderVert += shaderDef
+      shaderFrag += shaderDef
 
-      with open(shaderPath / "main3d.vert.glsl", "r", encoding="utf-8") as f:
-        shaderVert += f.read()
+    with open(shaderPath / "main3d.vert.glsl", "r", encoding="utf-8") as f:
+      shaderVert += f.read()
 
-      with open(shaderPath / "main3d.frag.glsl", "r", encoding="utf-8") as f:
-        shaderFrag += f.read()
+    with open(shaderPath / "main3d.frag.glsl", "r", encoding="utf-8") as f:
+      shaderFrag += f.read()
 
-      shader_info = gpu.types.GPUShaderCreateInfo()
-      
-      with open(shaderPath / "structs.glsl", "r", encoding="utf-8") as f:
-        shader_info.typedef_source(f.read())
-      
-      # vertex -> fragment
-      vert_out = gpu.types.GPUStageInterfaceInfo("vert_interface")
-      vert_out.no_perspective("VEC4", "cc_shade")
-      vert_out.flat("VEC4", "cc_shade_flat")
-      vert_out.smooth("VEC4", "uv")
-      vert_out.no_perspective("VEC2", "posScreen")
-      vert_out.flat("VEC4", "tileSize")
+    shader_info = gpu.types.GPUShaderCreateInfo()
+    
+    with open(shaderPath / "structs.glsl", "r", encoding="utf-8") as f:
+      shader_info.typedef_source(f.read())
+    
+    # vertex -> fragment
+    vert_out = gpu.types.GPUStageInterfaceInfo("vert_interface")
+    vert_out.no_perspective("VEC4", "cc_shade")
+    vert_out.flat("VEC4", "cc_shade_flat")
+    vert_out.smooth("VEC2", "inputUV")
+    vert_out.no_perspective("VEC2", "posScreen")
 
+    if self.use_atomic_rendering:
       shader_info.define("depth_unchanged", "depth_any")
-
       if self.shader_interlock_support:
         shader_info.define("USE_SHADER_INTERLOCK", "1")
+      shader_info.define("BLEND_EMULATION", "1")
+    # Using the already calculated view space normals instead of transforming the light direction makes
+    # for cleaner and faster code
+    shader_info.define("VIEWSPACE_LIGHTING", "0" if scene.fast64.renderSettings.useWorldSpaceLighting else "1")
+    shader_info.define("SIMULATE_LOW_PRECISION", "1")
 
-      shader_info.push_constant("MAT4", "matMVP")
-      shader_info.push_constant("MAT3", "matNorm")
+    shader_info.push_constant("MAT4", "matMVP")
+    shader_info.push_constant("MAT3", "matNorm")
 
-      shader_info.uniform_buf(0, "UBO_Material", "material")
-      
-      shader_info.vertex_in(0, "VEC3", "pos") # keep blenders name keep for better compat.
-      shader_info.vertex_in(1, "VEC3", "inNormal")
-      shader_info.vertex_in(2, "VEC4", "inColor")
-      shader_info.vertex_in(3, "VEC2", "inUV")
-      shader_info.vertex_out(vert_out)
-      
-      shader_info.sampler(0, "FLOAT_2D", "tex0")
-      shader_info.sampler(1, "FLOAT_2D", "tex1")
-      
+    shader_info.uniform_buf(0, "UBO_Material", "material")
+
+    shader_info.vertex_in(0, "VEC3", "pos") # keep blenders name keep for better compat.
+    shader_info.vertex_in(1, "VEC3", "inNormal")
+    shader_info.vertex_in(2, "VEC4", "inColor")
+    shader_info.vertex_in(3, "VEC2", "inUV")
+    shader_info.vertex_out(vert_out)
+    
+    for i in range(8):
+      shader_info.sampler(i, "FLOAT_2D", f"tex{i}")
+    
+    if self.use_atomic_rendering:
       shader_info.image(2, 'R32UI', "UINT_2D_ATOMIC", "color_texture", qualifiers={"READ", "WRITE"})
       shader_info.image(3, 'R32I',  "INT_2D_ATOMIC",  "depth_texture", qualifiers={"READ", "WRITE"})
-
+    else:
       shader_info.fragment_out(0, "VEC4", "FragColor")
 
-      shader_info.vertex_source(shaderVert)
-      shader_info.fragment_source(shaderFrag)
-      
-      self.shader = gpu.shader.create_from_info(shader_info)      
-      self.shader_fallback = gpu.shader.from_builtin('UNIFORM_COLOR')
+    shader_info.vertex_source(shaderVert)
+    shader_info.fragment_source(shaderFrag)
+    
+    self.shader = gpu.shader.create_from_info(shader_info)      
+    self.shader_fallback = gpu.shader.from_builtin('3D_UNIFORM_COLOR' if bpy.app.version < (4, 1, 0) else 'UNIFORM_COLOR')
+    self.vbo_format = self.shader.format_calc()
 
+  def init_shader_2d(self):
+    if not self.shader_2d:
+      print("Compiling 2D shader")
       # 2D shader (offscreen to viewport)
       shader_info = gpu.types.GPUShaderCreateInfo()
       vert_out = gpu.types.GPUStageInterfaceInfo("vert_2d")
@@ -183,25 +193,38 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
       self.shader_2d = gpu.shader.create_from_info(shader_info)                             
 
   def mesh_change_listener(scene, depsgraph):
-    global f64render_meshCache
-    global f64render_materials_dirty
-    global current_ucode
     # print("################ MESH CHANGE LISTENER ################")  
 
-    if depsgraph.id_type_updated('SCENE'):
-      if current_ucode != depsgraph.scene.f3d_type:
-        f64render_materials_dirty = True
-        current_ucode = depsgraph.scene.f3d_type
+    for update in depsgraph.updates:
+      if isinstance(update.id, bpy.types.Scene):
+        if F64_GLOBALS.current_ucode != update.id.f3d_type or F64_GLOBALS.current_gamemode != update.id.gameEditorMode:
+          F64_GLOBALS.materials_cache = {}
+          F64_GLOBALS.current_ucode, F64_GLOBALS.current_gamemode = update.id.f3d_type, update.id.gameEditorMode
+        world_lighting = update.id.fast64.renderSettings.useWorldSpaceLighting
+        if world_lighting != F64_GLOBALS.world_lighting:
+          F64_GLOBALS.world_lighting = world_lighting
+          F64_GLOBALS.rebuid_shaders = True
 
-    if depsgraph.id_type_updated('MATERIAL'):
-      for update in depsgraph.updates:
-        # this seems to trigger for all materials if only one changed (@TODO: check if i can get proper updates)
-        f64render_materials_dirty = True
+        F64_GLOBALS.clear_areas() # reset area lookup to refresh initial render state, is this the best approach?
+      if isinstance(update.id, bpy.types.Material) and update.id in F64_GLOBALS.materials_cache:
+        F64_GLOBALS.materials_cache.pop(update.id)
+      is_obj_update = isinstance(update.id, bpy.types.Object)
 
-    if depsgraph.id_type_updated('OBJECT'):
-      for update in depsgraph.updates:
-        if isinstance(update.id, bpy.types.Object) and update.id.type in {"MESH", "CURVE", "SURFACE", "FONT"}:
+      # support animating lights without uncaching materials, check if a light object was updated
+      if ((is_obj_update and isinstance(update.id.data, bpy.types.Light)) and update.id.name in F64_GLOBALS.obj_lights):
+        f64_parse_obj_light(
+          F64_GLOBALS.obj_lights[update.id.name], 
+          update.id, 
+          materials_set_light_direction(depsgraph.scene)
+        )
+      if is_obj_update and update.id.type in {"MESH", "CURVE", "SURFACE", "FONT"}:
+        F64_GLOBALS.clear_areas()
+        if update.is_updated_geometry:
           cache_del_by_mesh(update.id.data.name)
+
+  @bpy.app.handlers.persistent
+  def on_file_load(_context):
+    F64_GLOBALS.clear()
 
   def view_update(self, context, depsgraph):
     if self.draw_handler is None:
@@ -211,16 +234,19 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     for obj in depsgraph.objects:
       if obj.type == 'MESH' and obj.mode == 'EDIT':
         meshID = obj.name + "#" + obj.data.name
-        if meshID in f64render_meshCache:
-          del f64render_meshCache[meshID]
+        if meshID in F64_GLOBALS.meshCache:
+          del F64_GLOBALS.meshCache[meshID]
 
   def view_draw(self, context, depsgraph):
     self.draw_scene(context, depsgraph)
+    return # uncomment to profile individual functions
+    from cProfile import Profile
+    from pstats import SortKey, Stats
+    with Profile() as profile:
+      self.draw_scene(context, depsgraph)
+      Stats(profile).strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats()
 
   def draw_scene(self, context, depsgraph):
-    global f64render_meshCache
-    global f64render_materials_dirty
-    
     # TODO: fixme, after reloading this script during dev, something calls this function
     #       with an invalid reference (viewport?)
     if repr(self).endswith("invalid>"):
@@ -229,178 +255,50 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     t = time.process_time()
 
     space_view_3d = context.space_data
-    self.update_render_size(context.region.width, context.region.height)
-    self.color_texture.clear(format='UINT', value=[0x080808])
-    self.depth_texture.clear(format='INT', value=[0])
+    f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
+    always_set = f64render_rs.always_set
+    projection_matrix, view_matrix = context.region_data.perspective_matrix, context.region_data.view_matrix
+    self.use_atomic_rendering = bpy.app.version >= (4, 1, 0) and f64render_rs.use_atomic_rendering
 
-    self.init_shader()
+    if F64_GLOBALS.rebuid_shaders or self.shader is None:
+      F64_GLOBALS.rebuid_shaders = False
+      self.init_shader(context.scene)
+  
+    if self.use_atomic_rendering:
+      self.update_render_size(context.region.width, context.region.height)
+      self.color_texture.clear(format='UINT', value=[0x080808])
+      self.depth_texture.clear(format='INT', value=[0])
+
     self.shader.bind()
 
     # Enable depth test
     gpu.state.depth_test_set('LESS')
     gpu.state.depth_mask_set(True)
 
-    # global params
-    fast64_rs = depsgraph.scene.fast64.renderSettings
-    f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
-    lightDir0, lightDir1 = fast64_rs.light0Direction, fast64_rs.light1Direction
-    if not fast64_rs.useWorldSpaceLighting:
-      view_rotation = (mathutils.Quaternion((1, 0, 0), math.radians(90.0)) @ context.region_data.view_matrix.to_quaternion()).to_matrix()
-      lightDir0, lightDir1 = lightDir0 @ view_rotation, lightDir1 @ view_rotation
-
-    # Note: space conversion to Y-up happens indirectly during the normal matrix calculation
-    lightColor0 = fast64_rs.light0Color
-    lightColor1 = fast64_rs.light1Color
-    ambientColor = fast64_rs.ambientColor
-
-    lastPrimColor = f64render_rs.default_prim_color
-    last_prim_lod = np.array([0, 0], dtype=np.float32)
-    lastEnvColor = f64render_rs.default_env_color
-    last_ck = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32)
-    last_convert = np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)
-
-    fallback_objs = []
-    for obj in depsgraph.objects:
-      if obj.type in {"MESH", "CURVE", "SURFACE", "FONT"} and obj.data is not None:
-
-        meshID = obj.name + "#" + obj.data.name
-
-        # check for objects that transitioned from non-f3d to f3d materials
-        if meshID in f64render_meshCache:
-          renderObj = f64render_meshCache[meshID]
-          if len(renderObj.mat_data) == 0 and obj_has_f3d_materials(obj):
-            del f64render_meshCache[meshID]
-            
-        # Mesh not cached: parse & convert mesh data, then prepare a GPU batch
-        if meshID not in f64render_meshCache:
-          # print("    -> Update object", meshID)
-          if obj.mode == 'EDIT':
-            mesh = obj.evaluated_get(depsgraph).to_mesh()
-          else:
-            mesh = obj.evaluated_get(depsgraph).to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
-
-          renderObj = f64render_meshCache[meshID] = mesh_to_buffers(mesh)
-          renderObj.mesh_name = obj.data.name
-
-          mat_count = len(obj.material_slots)
-          renderObj.batch = batch_for_shader(self.shader,
-            renderObj.vert,
-            renderObj.norm,
-            renderObj.color,
-            renderObj.uv,
-            renderObj.indices
-          )
-
-          ubo_size = UNIFORM_BUFFER_STRUCT.size
-          ubo_size = (ubo_size + 15) & ~15 # force 16-byte alignment
-
-          renderObj.mat_data = [bytes(ubo_size)] * mat_count
-
-          renderObj.ubo_mat_data = [None] * mat_count
-          renderObj.materials = [None] * mat_count
-
-          for i in range(mat_count):
-            renderObj.ubo_mat_data[i] = gpu.types.GPUUniformBuf(renderObj.mat_data[i])
-
-          obj.to_mesh_clear()
-        
-        if not obj_has_f3d_materials(obj):
-          fallback_objs.append(obj)
-          continue
-        
-    self.shader.image('depth_texture', self.depth_texture)
-    self.shader.image('color_texture', self.color_texture)
+    if self.use_atomic_rendering:
+      self.shader.image('depth_texture', self.depth_texture)
+      self.shader.image('color_texture', self.color_texture)
 
     gpu.state.depth_test_set('NONE')
     gpu.state.depth_mask_set(False)
     gpu.state.blend_set("NONE")
 
     # get visible objects, this cannot be done in despgraph objects for whatever reason
-    hidden_obj = [ob.name for ob in bpy.context.view_layer.objects if not ob.visible_get() and ob.data is not None]
+    hidden_objs = {ob.name for ob in bpy.context.view_layer.objects if not ob.visible_get() and ob.data is not None}
 
-    # Draw opaque objects first, then transparent ones
-    #for obj in object_queue[0] + object_queue[1]:
-    for layer in range(2):
-      for obj in depsgraph.objects:
-        if obj.data is None: continue
-        # Handle "Local View" (pressing '/')
-        if space_view_3d.local_view and not obj.local_view_get(space_view_3d): continue
-        if obj.name in hidden_obj: continue
-        # print("Draw object", obj.data.session_uid, visible_obj_ids)
-  
-        # print("space_view_3d.local_view", space_view_3d.clip_start, space_view_3d.clip_end)
+    self.last_used_textures.clear()
+    match depsgraph.scene.gameEditorMode: # game mode implmentations
+      case "SM64":
+        draw_sm64_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
+      case "OOT":
+        draw_oot_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
+      case _:
+        render_state = get_scene_render_state(depsgraph.scene)
+        for obj in depsgraph.objects:
+          obj_info = collect_obj_info(self, obj, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
+          if obj_info is not None:
+            draw_f64_obj(self, render_state, obj_info)
 
-        meshID = obj.name + "#" + obj.data.name
-        if meshID not in f64render_meshCache: continue
-        # print("  -> Draw object", meshID)
-        renderObj: MeshBuffers = f64render_meshCache[meshID]
-
-        modelview_matrix = obj.matrix_world
-        projection_matrix = context.region_data.perspective_matrix
-        mvp_matrix = projection_matrix @ modelview_matrix
-        normal_matrix = (context.region_data.view_matrix @ obj.matrix_world).to_3x3().inverted().transposed()
-
-        self.shader.uniform_float("matMVP", mvp_matrix)
-        self.shader.uniform_float("matNorm", normal_matrix)
-
-        mat_idx = 0        
-        for slot in obj.material_slots:
-          indices_count = renderObj.index_offsets[mat_idx+1] - renderObj.index_offsets[mat_idx]
-          if indices_count == 0: # ignore unused materials
-            mat_idx += 1
-            continue
-          
-          f3d_mat = slot.material.f3d_mat                    
-          if f64render_materials_dirty or renderObj.materials[mat_idx] is None:
-            renderObj.materials[mat_idx] = f64_material_parse(f3d_mat, renderObj.materials[mat_idx])
-
-          f64mat = renderObj.materials[mat_idx]
-          if f64mat.queue != layer: # skip if not in current layer
-            mat_idx += 1
-            continue
-
-          gpu.state.face_culling_set(f64mat.cull)
-
-          if f64mat.tex0Buff: self.shader.uniform_sampler("tex0", f64mat.tex0Buff)
-          if f64mat.tex1Buff: self.shader.uniform_sampler("tex1", f64mat.tex1Buff)
-
-          renderObj.mat_data[mat_idx] = UNIFORM_BUFFER_STRUCT.pack(
-            *f64mat.blender,
-            *f64mat.tile_conf,
-            *f64mat.cc,
-            f64mat.geo_mode,
-            f64mat.othermode_l,
-            f64mat.othermode_h,
-            f64mat.flags,
-            *(f64mat.color_light if f64mat.set_light      else lightColor0),
-            *lightColor1,
-            *lightDir0,
-            f64mat.alphaClip,
-            *lightDir1,
-            0,
-            *(f64mat.color_prim    if f64mat.set_prim     else lastPrimColor),
-            *(f64mat.color_env     if f64mat.set_env      else lastEnvColor),
-            *(f64mat.color_ambient if f64mat.set_ambient  else ambientColor),
-            *(f64mat.ck            if f64mat.set_ck       else last_ck),
-            *(f64mat.lod_prim      if f64mat.set_prim     else last_prim_lod),
-            *f64mat.prim_depth,
-            *(f64mat.convert       if f64mat.set_convert  else last_convert),
-          )
-
-          if f64mat.set_prim: lastPrimColor, last_prim_lod = f64mat.color_prim, f64mat.lod_prim
-          if f64mat.set_env: lastEnvColor = f64mat.color_env
-          if f64mat.set_ck: last_ck = f64mat.ck
-          if f64mat.set_convert: last_convert = f64mat.convert
-          
-          renderObj.ubo_mat_data[mat_idx].update(renderObj.mat_data[mat_idx])                        
-          self.shader.uniform_block("material", renderObj.ubo_mat_data[mat_idx])
-          
-          # @TODO: frustum-culling (blender doesn't do it)
-          
-          renderObj.batch.draw_range(self.shader, elem_start=renderObj.index_offsets[mat_idx], elem_count=indices_count)
-          mat_idx += 1  
-
-    f64render_materials_dirty = False
     draw_time = (time.process_time() - t) * 1000
     self.time_total += draw_time
     self.time_count += 1
@@ -410,35 +308,9 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
       print("Time F3D AVG (ms)", self.time_total / self.time_count, self.time_count)
       self.time_total = 0
       self.time_count = 0
-          
-    if len(fallback_objs) > 0:
-      t = time.process_time()
-      self.shader_fallback.bind()
 
-      for obj in fallback_objs:
-        meshID = obj.name + "#" + obj.data.name
-        renderObj = f64render_meshCache[meshID]
-
-        if obj.name in hidden_obj: continue
-
-        # get material (we don't expect any changes here, so caching is fine)
-        if renderObj.materials is None or len(renderObj.materials) == 0:
-          renderObj.materials = [F64Material()]
-          if obj.material_slots:
-            mat = obj.material_slots[0].materials[0]
-            renderObj.materials[0] = node_material_parse(mat)
-
-        self.shader_fallback.uniform_float("color", renderObj.materials[0].color_prim)
-
-        modelview_matrix = obj.matrix_world
-        projection_matrix = context.region_data.perspective_matrix
-        mvp_matrix = projection_matrix @ modelview_matrix
-        self.shader_fallback.uniform_float("ModelViewProjectionMatrix", mvp_matrix)
-
-        renderObj.batch.draw(self.shader_fallback)
-        obj.to_mesh_clear()
-
-      #print("Time fallback (ms)", (time.process_time() - t) * 1000)
+    if not self.use_atomic_rendering:
+      return # when there's no access to color and depth aux images, we render directly, so skip final 2d draw
 
     #t = time.process_time()
     gpu.state.face_culling_set('NONE')
@@ -446,6 +318,7 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     gpu.state.depth_test_set('LESS')
     gpu.state.depth_mask_set(False)
 
+    self.init_shader_2d()
     self.shader_2d.bind()
     
     # @TODO: why can't i cache this?
@@ -458,27 +331,6 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
 
     #print("Time 2D (ms)", (time.process_time() - t) * 1000)
 
-class F64RenderSettings(bpy.types.PropertyGroup):
-  default_prim_color: bpy.props.FloatVectorProperty(
-    name="Default Prim Color",
-    default=(1, 1, 1, 1),
-    subtype="COLOR",
-    size=4,
-    min=0,
-    max=1,
-  )
-  default_env_color: bpy.props.FloatVectorProperty(
-    name="Default Env Color",
-    default=(0.5, 0.5, 0.5, 0.5),
-    subtype="COLOR",
-    size=4,
-    min=0,
-    max=1,
-  )
-
-class F64RenderProperties(bpy.types.PropertyGroup):
-  render_settings: bpy.props.PointerProperty(type=F64RenderSettings)
-
 class F64RenderSettingsPanel(bpy.types.Panel):
   bl_label = "f64render"
   bl_idname = "OBJECT_PT_F64RENDER_SETTINGS_PANEL"
@@ -486,13 +338,12 @@ class F64RenderSettingsPanel(bpy.types.Panel):
   bl_region_type = "WINDOW"
 
   def draw(self, context):
-    layout = self.layout
     f64render_rs: F64RenderSettings = context.scene.f64render.render_settings
-    layout.prop(f64render_rs, "default_prim_color")
-    layout.prop(f64render_rs, "default_env_color")
+    f64render_rs.draw_props(self.layout, context.scene.gameEditorMode)
 
-def draw_render_settings(self, context):
-  if context.scene.render.engine == Fast64RenderEngine.bl_idname:
+def draw_render_settings(self, context: bpy.types.Context):
+  space_data = context.space_data
+  if context.scene.render.engine == Fast64RenderEngine.bl_idname and space_data.type == "VIEW_3D" and space_data.shading.type in {"MATERIAL", "RENDERED"}:
     self.layout.popover(F64RenderSettingsPanel.bl_idname)
 
 # By default blender will hide quite a few panels like materials or vertex attributes
@@ -518,9 +369,6 @@ def get_panels():
     return panels
 
 def register():
-  global f64render_meshCache
-  f64render_meshCache = {}
-
   bpy.types.RenderEngine.f64_render_engine = bpy.props.PointerProperty(type=Fast64RenderEngine)
   for panel in get_panels():
     panel.COMPAT_ENGINES.add('FAST64_RENDER_ENGINE')
@@ -529,10 +377,9 @@ def register():
 
   bpy.types.VIEW3D_HT_header.append(draw_render_settings)
 
-def unregister():
-  global f64render_meshCache
-  f64render_meshCache = {}
+  F64_GLOBALS.clear()
 
+def unregister():
   bpy.types.VIEW3D_HT_header.remove(draw_render_settings)
 
   del bpy.types.RenderEngine.f64_render_engine

--- a/renderer.py
+++ b/renderer.py
@@ -20,372 +20,401 @@ yup_to_zup = mathutils.Quaternion((1, 0, 0), math.radians(90.0)).to_matrix().to_
 
 MISSING_TEXTURE_COLOR = (0, 0, 0, 1)
 
+
 def cache_del_by_mesh(mesh_name):
-  for key in list(F64_GLOBALS.meshCache.keys()):
-    if F64_GLOBALS.meshCache[key].mesh_name == mesh_name:
-      del F64_GLOBALS.meshCache[key]
+    for key in list(F64_GLOBALS.meshCache.keys()):
+        if F64_GLOBALS.meshCache[key].mesh_name == mesh_name:
+            del F64_GLOBALS.meshCache[key]
+
 
 def obj_has_f3d_materials(obj):
-  for slot in obj.material_slots:
-    if slot.material.is_f3d and slot.material.f3d_mat:
-      return True
-  return False
+    for slot in obj.material_slots:
+        if slot.material.is_f3d and slot.material.f3d_mat:
+            return True
+    return False
+
 
 def materials_set_light_direction(scene):
-  return not (scene.gameEditorMode == "SM64" and scene.fast64.sm64.matstack_fix)
+    return not (scene.gameEditorMode == "SM64" and scene.fast64.sm64.matstack_fix)
+
 
 class Fast64RenderEngine(bpy.types.RenderEngine):
-  bl_idname = "FAST64_RENDER_ENGINE"
-  bl_label = "Fast64 Renderer"
-  bl_use_preview = False
+    bl_idname = "FAST64_RENDER_ENGINE"
+    bl_label = "Fast64 Renderer"
+    bl_use_preview = False
 
-  def __init__(self):
-    super().__init__()
-    addon_set_fast64_path()
+    def __init__(self):
+        super().__init__()
+        addon_set_fast64_path()
 
-    self.shader = None
-    self.shader_2d = None
-    self.shader_fallback = None
-    self.vbo_format = None
-    self.draw_handler = None
-    self.use_atomic_rendering = True
+        self.shader = None
+        self.shader_2d = None
+        self.shader_fallback = None
+        self.vbo_format = None
+        self.draw_handler = None
+        self.use_atomic_rendering = True
 
-    self.last_used_textures: dict[int, gpu.types.GPUTexture] = {}
+        self.last_used_textures: dict[int, gpu.types.GPUTexture] = {}
 
-    self.time_count = 0
-    self.time_total = 0
-        
-    self.depth_texture: gpu.types.GPUTexture = None
-    self.color_texture: gpu.types.GPUTexture = None
-    self.update_render_size(128, 128)
+        self.time_count = 0
+        self.time_total = 0
 
-    bpy.app.handlers.depsgraph_update_post.append(Fast64RenderEngine.mesh_change_listener)
-    bpy.app.handlers.frame_change_post.append(Fast64RenderEngine.mesh_change_listener)
-    bpy.app.handlers.load_pre.append(Fast64RenderEngine.on_file_load)
+        self.depth_texture: gpu.types.GPUTexture = None
+        self.color_texture: gpu.types.GPUTexture = None
+        self.update_render_size(128, 128)
 
-    if "f64render_missing_texture" not in bpy.data.images:
-      # Create a 1x1 image
-      bpy.data.images.new("f64render_missing_texture", 1, 1).pixels = MISSING_TEXTURE_COLOR
+        bpy.app.handlers.depsgraph_update_post.append(Fast64RenderEngine.mesh_change_listener)
+        bpy.app.handlers.frame_change_post.append(Fast64RenderEngine.mesh_change_listener)
+        bpy.app.handlers.load_pre.append(Fast64RenderEngine.on_file_load)
 
-    ext_list = gpu.capabilities.extensions_get()
-    self.shader_interlock_support = 'GL_ARB_fragment_shader_interlock' in ext_list
-    if not self.shader_interlock_support:
-      print("\n\nWarning: GL_ARB_fragment_shader_interlock not supported!\n\n")
-    if bpy.app.version < (4, 1, 0):
-      print("\n\nWarning: Blender version too old! Expect limited blending emulation!\n\n")
-    self.draw_range_impl = bpy.app.version >= (3, 6, 0)
+        if "f64render_missing_texture" not in bpy.data.images:
+            # Create a 1x1 image
+            bpy.data.images.new("f64render_missing_texture", 1, 1).pixels = MISSING_TEXTURE_COLOR
 
-  def __del__(self):
-    def remove_handler(handler, func):
-      while func in handler:
-        handler.remove(func)
-    remove_handler(bpy.app.handlers.depsgraph_update_post, Fast64RenderEngine.mesh_change_listener)
-    remove_handler(bpy.app.handlers.frame_change_post, Fast64RenderEngine.mesh_change_listener)
-    remove_handler(bpy.app.handlers.load_pre, Fast64RenderEngine.on_file_load)
+        ext_list = gpu.capabilities.extensions_get()
+        self.shader_interlock_support = "GL_ARB_fragment_shader_interlock" in ext_list
+        if not self.shader_interlock_support:
+            print("\n\nWarning: GL_ARB_fragment_shader_interlock not supported!\n\n")
+        if bpy.app.version < (4, 1, 0):
+            print("\n\nWarning: Blender version too old! Expect limited blending emulation!\n\n")
+        self.draw_range_impl = bpy.app.version >= (3, 6, 0)
 
-  def update_render_size(self, size_x, size_y):
-    if not self.depth_texture or size_x != self.depth_texture.width or size_y != self.depth_texture.height:
-      self.depth_texture = gpu.types.GPUTexture((size_x, size_y), format='R32I')
-      self.color_texture = gpu.types.GPUTexture((size_x, size_y), format='R32UI')
+    def __del__(self):
+        def remove_handler(handler, func):
+            while func in handler:
+                handler.remove(func)
 
-  def init_shader(self, scene: bpy.types.Scene):
-    print("Compiling shader")
+        remove_handler(bpy.app.handlers.depsgraph_update_post, Fast64RenderEngine.mesh_change_listener)
+        remove_handler(bpy.app.handlers.frame_change_post, Fast64RenderEngine.mesh_change_listener)
+        remove_handler(bpy.app.handlers.load_pre, Fast64RenderEngine.on_file_load)
 
-    shaderPath = (pathlib.Path(__file__).parent / "shader").resolve()
-    shaderVert = ""
-    shaderFrag = ""
+    def update_render_size(self, size_x, size_y):
+        if not self.depth_texture or size_x != self.depth_texture.width or size_y != self.depth_texture.height:
+            self.depth_texture = gpu.types.GPUTexture((size_x, size_y), format="R32I")
+            self.color_texture = gpu.types.GPUTexture((size_x, size_y), format="R32UI")
 
-    with open(shaderPath / "utils.glsl", "r", encoding="utf-8") as f:
-      shaderUtils = f.read()
-      shaderVert += shaderUtils
-      shaderFrag += shaderUtils
+    def init_shader(self, scene: bpy.types.Scene):
+        print("Compiling shader")
 
-    with open(shaderPath / "defines.glsl", "r", encoding="utf-8") as f:
-      shaderDef = f.read()
-      shaderVert += shaderDef
-      shaderFrag += shaderDef
+        shaderPath = (pathlib.Path(__file__).parent / "shader").resolve()
+        shaderVert = ""
+        shaderFrag = ""
 
-    with open(shaderPath / "main3d.vert.glsl", "r", encoding="utf-8") as f:
-      shaderVert += f.read()
+        with open(shaderPath / "utils.glsl", "r", encoding="utf-8") as f:
+            shaderUtils = f.read()
+            shaderVert += shaderUtils
+            shaderFrag += shaderUtils
 
-    with open(shaderPath / "main3d.frag.glsl", "r", encoding="utf-8") as f:
-      shaderFrag += f.read()
+        with open(shaderPath / "defines.glsl", "r", encoding="utf-8") as f:
+            shaderDef = f.read()
+            shaderVert += shaderDef
+            shaderFrag += shaderDef
 
-    shader_info = gpu.types.GPUShaderCreateInfo()
-    
-    with open(shaderPath / "structs.glsl", "r", encoding="utf-8") as f:
-      shader_info.typedef_source(f.read())
-    
-    # vertex -> fragment
-    vert_out = gpu.types.GPUStageInterfaceInfo("vert_interface")
-    vert_out.no_perspective("VEC4", "cc_shade")
-    vert_out.flat("VEC4", "cc_shade_flat")
-    vert_out.smooth("VEC2", "inputUV")
-    vert_out.no_perspective("VEC2", "posScreen")
+        with open(shaderPath / "main3d.vert.glsl", "r", encoding="utf-8") as f:
+            shaderVert += f.read()
 
-    if self.use_atomic_rendering:
-      shader_info.define("depth_unchanged", "depth_any")
-      if self.shader_interlock_support:
-        shader_info.define("USE_SHADER_INTERLOCK", "1")
-      shader_info.define("BLEND_EMULATION", "1")
-    # Using the already calculated view space normals instead of transforming the light direction makes
-    # for cleaner and faster code
-    shader_info.define("VIEWSPACE_LIGHTING", "0" if scene.fast64.renderSettings.useWorldSpaceLighting else "1")
-    shader_info.define("SIMULATE_LOW_PRECISION", "1")
+        with open(shaderPath / "main3d.frag.glsl", "r", encoding="utf-8") as f:
+            shaderFrag += f.read()
 
-    shader_info.push_constant("MAT4", "matMVP")
-    shader_info.push_constant("MAT3", "matNorm")
+        shader_info = gpu.types.GPUShaderCreateInfo()
 
-    shader_info.uniform_buf(0, "UBO_Material", "material")
+        with open(shaderPath / "structs.glsl", "r", encoding="utf-8") as f:
+            shader_info.typedef_source(f.read())
 
-    shader_info.vertex_in(0, "VEC3", "pos") # keep blenders name keep for better compat.
-    shader_info.vertex_in(1, "VEC3", "inNormal")
-    shader_info.vertex_in(2, "VEC4", "inColor")
-    shader_info.vertex_in(3, "VEC2", "inUV")
-    shader_info.vertex_out(vert_out)
-    
-    for i in range(8):
-      shader_info.sampler(i, "FLOAT_2D", f"tex{i}")
-    
-    if self.use_atomic_rendering:
-      shader_info.image(2, 'R32UI', "UINT_2D_ATOMIC", "color_texture", qualifiers={"READ", "WRITE"})
-      shader_info.image(3, 'R32I',  "INT_2D_ATOMIC",  "depth_texture", qualifiers={"READ", "WRITE"})
-    else:
-      shader_info.fragment_out(0, "VEC4", "FragColor")
+        # vertex -> fragment
+        vert_out = gpu.types.GPUStageInterfaceInfo("vert_interface")
+        vert_out.no_perspective("VEC4", "cc_shade")
+        vert_out.flat("VEC4", "cc_shade_flat")
+        vert_out.smooth("VEC2", "inputUV")
+        vert_out.no_perspective("VEC2", "posScreen")
 
-    shader_info.vertex_source(shaderVert)
-    shader_info.fragment_source(shaderFrag)
-    
-    self.shader = gpu.shader.create_from_info(shader_info)      
-    self.shader_fallback = gpu.shader.from_builtin('3D_UNIFORM_COLOR' if bpy.app.version < (4, 1, 0) else 'UNIFORM_COLOR')
-    self.vbo_format = self.shader.format_calc()
+        if self.use_atomic_rendering:
+            shader_info.define("depth_unchanged", "depth_any")
+            if self.shader_interlock_support:
+                shader_info.define("USE_SHADER_INTERLOCK", "1")
+            shader_info.define("BLEND_EMULATION", "1")
+        # Using the already calculated view space normals instead of transforming the light direction makes
+        # for cleaner and faster code
+        shader_info.define("VIEWSPACE_LIGHTING", "0" if scene.fast64.renderSettings.useWorldSpaceLighting else "1")
+        shader_info.define("SIMULATE_LOW_PRECISION", "1")
 
-  def init_shader_2d(self):
-    if not self.shader_2d:
-      print("Compiling 2D shader")
-      # 2D shader (offscreen to viewport)
-      shader_info = gpu.types.GPUShaderCreateInfo()
-      vert_out = gpu.types.GPUStageInterfaceInfo("vert_2d")
-      vert_out.smooth("VEC2", "uv")
+        shader_info.push_constant("MAT4", "matMVP")
+        shader_info.push_constant("MAT3", "matNorm")
 
-      # Hacky workaround for blender forcing an early depth test ('layout(depth_unchanged) out float gl_FragDepth;')
-      shader_info.define("depth_unchanged", "depth_any")
-      shader_info.image(2, 'R32UI', "UINT_2D_ATOMIC", "color_texture", qualifiers={"READ"})
+        shader_info.uniform_buf(0, "UBO_Material", "material")
 
-      shader_info.fragment_out(0, "VEC4", "FragColor")
-      shader_info.vertex_in(0, "VEC2", "pos")
-      shader_info.vertex_out(vert_out)
+        shader_info.vertex_in(0, "VEC3", "pos")  # keep blenders name keep for better compat.
+        shader_info.vertex_in(1, "VEC3", "inNormal")
+        shader_info.vertex_in(2, "VEC4", "inColor")
+        shader_info.vertex_in(3, "VEC2", "inUV")
+        shader_info.vertex_out(vert_out)
 
-      shader_info.vertex_source("""
+        for i in range(8):
+            shader_info.sampler(i, "FLOAT_2D", f"tex{i}")
+
+        if self.use_atomic_rendering:
+            shader_info.image(2, "R32UI", "UINT_2D_ATOMIC", "color_texture", qualifiers={"READ", "WRITE"})
+            shader_info.image(3, "R32I", "INT_2D_ATOMIC", "depth_texture", qualifiers={"READ", "WRITE"})
+        else:
+            shader_info.fragment_out(0, "VEC4", "FragColor")
+
+        shader_info.vertex_source(shaderVert)
+        shader_info.fragment_source(shaderFrag)
+
+        self.shader = gpu.shader.create_from_info(shader_info)
+        self.shader_fallback = gpu.shader.from_builtin(
+            "3D_UNIFORM_COLOR" if bpy.app.version < (4, 1, 0) else "UNIFORM_COLOR"
+        )
+        self.vbo_format = self.shader.format_calc()
+
+    def init_shader_2d(self):
+        if not self.shader_2d:
+            print("Compiling 2D shader")
+            # 2D shader (offscreen to viewport)
+            shader_info = gpu.types.GPUShaderCreateInfo()
+            vert_out = gpu.types.GPUStageInterfaceInfo("vert_2d")
+            vert_out.smooth("VEC2", "uv")
+
+            # Hacky workaround for blender forcing an early depth test ('layout(depth_unchanged) out float gl_FragDepth;')
+            shader_info.define("depth_unchanged", "depth_any")
+            shader_info.image(2, "R32UI", "UINT_2D_ATOMIC", "color_texture", qualifiers={"READ"})
+
+            shader_info.fragment_out(0, "VEC4", "FragColor")
+            shader_info.vertex_in(0, "VEC2", "pos")
+            shader_info.vertex_out(vert_out)
+
+            shader_info.vertex_source(
+                """
         void main() {
           gl_Position = vec4(pos, 0.0, 1.0);
           uv = pos.xy * 0.5 + 0.5;
-        }""")
-      
-      shader_info.fragment_source("""
+        }"""
+            )
+
+            shader_info.fragment_source(
+                """
         void main() {
           ivec2 textureSize2d = imageSize(color_texture);
           ivec2 coord = ivec2(uv.xy * vec2(textureSize2d)); 
           FragColor =  unpackUnorm4x8(imageLoad(color_texture, coord).r);
           gl_FragDepth = 0.99999;
-        }""")
-      
-      self.shader_2d = gpu.shader.create_from_info(shader_info)                             
+        }"""
+            )
 
-  def mesh_change_listener(scene, depsgraph):
-    # print("################ MESH CHANGE LISTENER ################")  
+            self.shader_2d = gpu.shader.create_from_info(shader_info)
 
-    for update in depsgraph.updates:
-      if isinstance(update.id, bpy.types.Scene):
-        if F64_GLOBALS.current_ucode != update.id.f3d_type or F64_GLOBALS.current_gamemode != update.id.gameEditorMode:
-          F64_GLOBALS.materials_cache = {}
-          F64_GLOBALS.current_ucode, F64_GLOBALS.current_gamemode = update.id.f3d_type, update.id.gameEditorMode
-        world_lighting = update.id.fast64.renderSettings.useWorldSpaceLighting
-        if world_lighting != F64_GLOBALS.world_lighting:
-          F64_GLOBALS.world_lighting = world_lighting
-          F64_GLOBALS.rebuid_shaders = True
+    def mesh_change_listener(scene, depsgraph):
+        # print("################ MESH CHANGE LISTENER ################")
 
-        F64_GLOBALS.clear_areas() # reset area lookup to refresh initial render state, is this the best approach?
-      if isinstance(update.id, bpy.types.Material) and update.id in F64_GLOBALS.materials_cache:
-        F64_GLOBALS.materials_cache.pop(update.id)
-      is_obj_update = isinstance(update.id, bpy.types.Object)
+        for update in depsgraph.updates:
+            if isinstance(update.id, bpy.types.Scene):
+                if (
+                    F64_GLOBALS.current_ucode != update.id.f3d_type
+                    or F64_GLOBALS.current_gamemode != update.id.gameEditorMode
+                ):
+                    F64_GLOBALS.materials_cache = {}
+                    F64_GLOBALS.current_ucode, F64_GLOBALS.current_gamemode = (
+                        update.id.f3d_type,
+                        update.id.gameEditorMode,
+                    )
+                world_lighting = update.id.fast64.renderSettings.useWorldSpaceLighting
+                if world_lighting != F64_GLOBALS.world_lighting:
+                    F64_GLOBALS.world_lighting = world_lighting
+                    F64_GLOBALS.rebuid_shaders = True
 
-      # support animating lights without uncaching materials, check if a light object was updated
-      if ((is_obj_update and isinstance(update.id.data, bpy.types.Light)) and update.id.name in F64_GLOBALS.obj_lights):
-        f64_parse_obj_light(
-          F64_GLOBALS.obj_lights[update.id.name], 
-          update.id, 
-          materials_set_light_direction(depsgraph.scene)
-        )
-      if is_obj_update and update.id.type in {"MESH", "CURVE", "SURFACE", "FONT"}:
-        F64_GLOBALS.clear_areas()
-        if update.is_updated_geometry:
-          cache_del_by_mesh(update.id.data.name)
+                F64_GLOBALS.clear_areas()  # reset area lookup to refresh initial render state, is this the best approach?
+            if isinstance(update.id, bpy.types.Material) and update.id in F64_GLOBALS.materials_cache:
+                F64_GLOBALS.materials_cache.pop(update.id)
+            is_obj_update = isinstance(update.id, bpy.types.Object)
 
-  @bpy.app.handlers.persistent
-  def on_file_load(_context):
-    F64_GLOBALS.clear()
+            # support animating lights without uncaching materials, check if a light object was updated
+            if (
+                is_obj_update and isinstance(update.id.data, bpy.types.Light)
+            ) and update.id.name in F64_GLOBALS.obj_lights:
+                f64_parse_obj_light(
+                    F64_GLOBALS.obj_lights[update.id.name], update.id, materials_set_light_direction(depsgraph.scene)
+                )
+            if is_obj_update and update.id.type in {"MESH", "CURVE", "SURFACE", "FONT"}:
+                F64_GLOBALS.clear_areas()
+                if update.is_updated_geometry:
+                    cache_del_by_mesh(update.id.data.name)
 
-  def view_update(self, context, depsgraph):
-    if self.draw_handler is None:
-      self.draw_handler = bpy.types.SpaceView3D.draw_handler_add(self.draw_scene, (context, depsgraph), 'WINDOW', 'POST_VIEW')
+    @bpy.app.handlers.persistent
+    def on_file_load(_context):
+        F64_GLOBALS.clear()
 
-    # this causes the mesh to update during edit-mode
-    for obj in depsgraph.objects:
-      if obj.type == 'MESH' and obj.mode == 'EDIT':
-        meshID = obj.name + "#" + obj.data.name
-        if meshID in F64_GLOBALS.meshCache:
-          del F64_GLOBALS.meshCache[meshID]
+    def view_update(self, context, depsgraph):
+        if self.draw_handler is None:
+            self.draw_handler = bpy.types.SpaceView3D.draw_handler_add(
+                self.draw_scene, (context, depsgraph), "WINDOW", "POST_VIEW"
+            )
 
-  def view_draw(self, context, depsgraph):
-    self.draw_scene(context, depsgraph)
-    return # uncomment to profile individual functions
-    from cProfile import Profile
-    from pstats import SortKey, Stats
-    with Profile() as profile:
-      self.draw_scene(context, depsgraph)
-      Stats(profile).strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats()
-
-  def draw_scene(self, context, depsgraph):
-    # TODO: fixme, after reloading this script during dev, something calls this function
-    #       with an invalid reference (viewport?)
-    if repr(self).endswith("invalid>"):
-        return
-
-    t = time.process_time()
-
-    space_view_3d = context.space_data
-    f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
-    always_set = f64render_rs.always_set
-    projection_matrix, view_matrix = context.region_data.perspective_matrix, context.region_data.view_matrix
-    self.use_atomic_rendering = bpy.app.version >= (4, 1, 0) and f64render_rs.use_atomic_rendering
-
-    if F64_GLOBALS.rebuid_shaders or self.shader is None:
-      F64_GLOBALS.rebuid_shaders = False
-      self.init_shader(context.scene)
-  
-    if self.use_atomic_rendering:
-      self.update_render_size(context.region.width, context.region.height)
-      self.color_texture.clear(format='UINT', value=[0x080808])
-      self.depth_texture.clear(format='INT', value=[0])
-
-    self.shader.bind()
-
-    # Enable depth test
-    gpu.state.depth_test_set('LESS')
-    gpu.state.depth_mask_set(True)
-
-    if self.use_atomic_rendering:
-      self.shader.image('depth_texture', self.depth_texture)
-      self.shader.image('color_texture', self.color_texture)
-
-    gpu.state.depth_test_set('NONE')
-    gpu.state.depth_mask_set(False)
-    gpu.state.blend_set("NONE")
-
-    # get visible objects, this cannot be done in despgraph objects for whatever reason
-    hidden_objs = {ob.name for ob in bpy.context.view_layer.objects if not ob.visible_get() and ob.data is not None}
-
-    self.last_used_textures.clear()
-    match depsgraph.scene.gameEditorMode: # game mode implmentations
-      case "SM64":
-        draw_sm64_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
-      case "OOT":
-        draw_oot_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
-      case _:
-        render_state = get_scene_render_state(depsgraph.scene)
+        # this causes the mesh to update during edit-mode
         for obj in depsgraph.objects:
-          obj_info = collect_obj_info(self, obj, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
-          if obj_info is not None:
-            draw_f64_obj(self, render_state, obj_info)
+            if obj.type == "MESH" and obj.mode == "EDIT":
+                meshID = obj.name + "#" + obj.data.name
+                if meshID in F64_GLOBALS.meshCache:
+                    del F64_GLOBALS.meshCache[meshID]
 
-    draw_time = (time.process_time() - t) * 1000
-    self.time_total += draw_time
-    self.time_count += 1
-    #print("Time F3D (ms)", draw_time)
+    def view_draw(self, context, depsgraph):
+        self.draw_scene(context, depsgraph)
+        return  # uncomment to profile individual functions
+        from cProfile import Profile
+        from pstats import SortKey, Stats
 
-    if self.time_count > 20:
-      print("Time F3D AVG (ms)", self.time_total / self.time_count, self.time_count)
-      self.time_total = 0
-      self.time_count = 0
+        with Profile() as profile:
+            self.draw_scene(context, depsgraph)
+            Stats(profile).strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats()
 
-    if not self.use_atomic_rendering:
-      return # when there's no access to color and depth aux images, we render directly, so skip final 2d draw
+    def draw_scene(self, context, depsgraph):
+        # TODO: fixme, after reloading this script during dev, something calls this function
+        #       with an invalid reference (viewport?)
+        if repr(self).endswith("invalid>"):
+            return
 
-    #t = time.process_time()
-    gpu.state.face_culling_set('NONE')
-    gpu.state.blend_set("ALPHA")
-    gpu.state.depth_test_set('LESS')
-    gpu.state.depth_mask_set(False)
+        t = time.process_time()
 
-    self.init_shader_2d()
-    self.shader_2d.bind()
-    
-    # @TODO: why can't i cache this?
-    vbo_2d = gpu.types.GPUVertBuf(self.shader_2d.format_calc(), 6)
-    vbo_2d.attr_fill("pos", [(-1, -1), (-1, 1), (1, 1), (1, 1), (1, -1), (-1, -1)])
-    batch_2d = gpu.types.GPUBatch(type="TRIS", buf=vbo_2d)
+        space_view_3d = context.space_data
+        f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
+        always_set = f64render_rs.always_set
+        projection_matrix, view_matrix = context.region_data.perspective_matrix, context.region_data.view_matrix
+        self.use_atomic_rendering = bpy.app.version >= (4, 1, 0) and f64render_rs.use_atomic_rendering
 
-    self.shader_2d.image('color_texture', self.color_texture)
-    batch_2d.draw(self.shader_2d)
+        if F64_GLOBALS.rebuid_shaders or self.shader is None:
+            F64_GLOBALS.rebuid_shaders = False
+            self.init_shader(context.scene)
 
-    #print("Time 2D (ms)", (time.process_time() - t) * 1000)
+        if self.use_atomic_rendering:
+            self.update_render_size(context.region.width, context.region.height)
+            self.color_texture.clear(format="UINT", value=[0x080808])
+            self.depth_texture.clear(format="INT", value=[0])
+
+        self.shader.bind()
+
+        # Enable depth test
+        gpu.state.depth_test_set("LESS")
+        gpu.state.depth_mask_set(True)
+
+        if self.use_atomic_rendering:
+            self.shader.image("depth_texture", self.depth_texture)
+            self.shader.image("color_texture", self.color_texture)
+
+        gpu.state.depth_test_set("NONE")
+        gpu.state.depth_mask_set(False)
+        gpu.state.blend_set("NONE")
+
+        # get visible objects, this cannot be done in despgraph objects for whatever reason
+        hidden_objs = {ob.name for ob in bpy.context.view_layer.objects if not ob.visible_get() and ob.data is not None}
+
+        self.last_used_textures.clear()
+        match depsgraph.scene.gameEditorMode:  # game mode implmentations
+            case "SM64":
+                draw_sm64_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
+            case "OOT":
+                draw_oot_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
+            case _:
+                render_state = get_scene_render_state(depsgraph.scene)
+                for obj in depsgraph.objects:
+                    obj_info = collect_obj_info(
+                        self, obj, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set
+                    )
+                    if obj_info is not None:
+                        draw_f64_obj(self, render_state, obj_info)
+
+        draw_time = (time.process_time() - t) * 1000
+        self.time_total += draw_time
+        self.time_count += 1
+        # print("Time F3D (ms)", draw_time)
+
+        if self.time_count > 20:
+            print("Time F3D AVG (ms)", self.time_total / self.time_count, self.time_count)
+            self.time_total = 0
+            self.time_count = 0
+
+        if not self.use_atomic_rendering:
+            return  # when there's no access to color and depth aux images, we render directly, so skip final 2d draw
+
+        # t = time.process_time()
+        gpu.state.face_culling_set("NONE")
+        gpu.state.blend_set("ALPHA")
+        gpu.state.depth_test_set("LESS")
+        gpu.state.depth_mask_set(False)
+
+        self.init_shader_2d()
+        self.shader_2d.bind()
+
+        # @TODO: why can't i cache this?
+        vbo_2d = gpu.types.GPUVertBuf(self.shader_2d.format_calc(), 6)
+        vbo_2d.attr_fill("pos", [(-1, -1), (-1, 1), (1, 1), (1, 1), (1, -1), (-1, -1)])
+        batch_2d = gpu.types.GPUBatch(type="TRIS", buf=vbo_2d)
+
+        self.shader_2d.image("color_texture", self.color_texture)
+        batch_2d.draw(self.shader_2d)
+
+        # print("Time 2D (ms)", (time.process_time() - t) * 1000)
+
 
 class F64RenderSettingsPanel(bpy.types.Panel):
-  bl_label = "f64render"
-  bl_idname = "OBJECT_PT_F64RENDER_SETTINGS_PANEL"
-  bl_space_type = "VIEW_3D"
-  bl_region_type = "WINDOW"
+    bl_label = "f64render"
+    bl_idname = "OBJECT_PT_F64RENDER_SETTINGS_PANEL"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "WINDOW"
 
-  def draw(self, context):
-    f64render_rs: F64RenderSettings = context.scene.f64render.render_settings
-    f64render_rs.draw_props(self.layout, context.scene.gameEditorMode)
+    def draw(self, context):
+        f64render_rs: F64RenderSettings = context.scene.f64render.render_settings
+        f64render_rs.draw_props(self.layout, context.scene.gameEditorMode)
+
 
 def draw_render_settings(self, context: bpy.types.Context):
-  space_data = context.space_data
-  if context.scene.render.engine == Fast64RenderEngine.bl_idname and space_data.type == "VIEW_3D" and space_data.shading.type in {"MATERIAL", "RENDERED"}:
-    self.layout.popover(F64RenderSettingsPanel.bl_idname)
+    space_data = context.space_data
+    if (
+        context.scene.render.engine == Fast64RenderEngine.bl_idname
+        and space_data.type == "VIEW_3D"
+        and space_data.shading.type in {"MATERIAL", "RENDERED"}
+    ):
+        self.layout.popover(F64RenderSettingsPanel.bl_idname)
+
 
 # By default blender will hide quite a few panels like materials or vertex attributes
 # Add this method to override the check blender does by render engine
 def get_panels():
     exclude_panels = {
-      'VIEWLAYER_PT_filter',
-        'VIEWLAYER_PT_layer_passes',
+        "VIEWLAYER_PT_filter",
+        "VIEWLAYER_PT_layer_passes",
     }
-    
-    include_panels = {
-      'EEVEE_MATERIAL_PT_context_material',
-      'MATERIAL_PT_preview'
-    }
+
+    include_panels = {"EEVEE_MATERIAL_PT_context_material", "MATERIAL_PT_preview"}
 
     panels = []
     for panel in bpy.types.Panel.__subclasses__():
-      if hasattr(panel, 'COMPAT_ENGINES'):
-        if (('BLENDER_RENDER' in panel.COMPAT_ENGINES and panel.__name__ not in exclude_panels)
-          or panel.__name__ in include_panels):
-          panels.append(panel)
+        if hasattr(panel, "COMPAT_ENGINES"):
+            if (
+                "BLENDER_RENDER" in panel.COMPAT_ENGINES and panel.__name__ not in exclude_panels
+            ) or panel.__name__ in include_panels:
+                panels.append(panel)
 
     return panels
 
+
 def register():
-  bpy.types.RenderEngine.f64_render_engine = bpy.props.PointerProperty(type=Fast64RenderEngine)
-  for panel in get_panels():
-    panel.COMPAT_ENGINES.add('FAST64_RENDER_ENGINE')
+    bpy.types.RenderEngine.f64_render_engine = bpy.props.PointerProperty(type=Fast64RenderEngine)
+    for panel in get_panels():
+        panel.COMPAT_ENGINES.add("FAST64_RENDER_ENGINE")
 
-  bpy.types.Scene.f64render = bpy.props.PointerProperty(type=F64RenderProperties)
+    bpy.types.Scene.f64render = bpy.props.PointerProperty(type=F64RenderProperties)
 
-  bpy.types.VIEW3D_HT_header.append(draw_render_settings)
+    bpy.types.VIEW3D_HT_header.append(draw_render_settings)
 
-  F64_GLOBALS.clear()
+    F64_GLOBALS.clear()
+
 
 def unregister():
-  bpy.types.VIEW3D_HT_header.remove(draw_render_settings)
+    bpy.types.VIEW3D_HT_header.remove(draw_render_settings)
 
-  del bpy.types.RenderEngine.f64_render_engine
+    del bpy.types.RenderEngine.f64_render_engine
 
-  for panel in get_panels():
-    if 'FAST64_RENDER_ENGINE' in panel.COMPAT_ENGINES:
-      panel.COMPAT_ENGINES.remove('FAST64_RENDER_ENGINE')
+    for panel in get_panels():
+        if "FAST64_RENDER_ENGINE" in panel.COMPAT_ENGINES:
+            panel.COMPAT_ENGINES.remove("FAST64_RENDER_ENGINE")
 
-  del bpy.types.Scene.f64render
+    del bpy.types.Scene.f64render

--- a/renderer.py
+++ b/renderer.py
@@ -43,8 +43,8 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     bl_label = "Fast64 Renderer"
     bl_use_preview = False
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         addon_set_fast64_path()
 
         self.shader = None

--- a/renderer.py
+++ b/renderer.py
@@ -383,7 +383,7 @@ def get_panels():
         "VIEWLAYER_PT_layer_passes",
     }
 
-    include_panels = {"EEVEE_MATERIAL_PT_context_material", "MATERIAL_PT_preview"}
+    include_panels = {"EEVEE_MATERIAL_PT_context_material", "MATERIAL_PT_preview", "DATA_PT_EEVEE_light"}
 
     panels = []
     for panel in bpy.types.Panel.__subclasses__():

--- a/renderer.py
+++ b/renderer.py
@@ -220,7 +220,7 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
                 world_lighting = update.id.fast64.renderSettings.useWorldSpaceLighting
                 if world_lighting != F64_GLOBALS.world_lighting:
                     F64_GLOBALS.world_lighting = world_lighting
-                    F64_GLOBALS.rebuid_shaders = True
+                    F64_GLOBALS.rebuild_shaders = True
 
                 F64_GLOBALS.clear_areas()  # reset area lookup to refresh initial render state, is this the best approach?
             if isinstance(update.id, bpy.types.Material) and update.id in F64_GLOBALS.materials_cache:
@@ -280,8 +280,8 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
         projection_matrix, view_matrix = context.region_data.perspective_matrix, context.region_data.view_matrix
         self.use_atomic_rendering = bpy.app.version >= (4, 1, 0) and f64render_rs.use_atomic_rendering
 
-        if F64_GLOBALS.rebuid_shaders or self.shader is None:
-            F64_GLOBALS.rebuid_shaders = False
+        if F64_GLOBALS.rebuild_shaders or self.shader is None:
+            F64_GLOBALS.rebuild_shaders = False
             self.init_shader(context.scene)
 
         if self.use_atomic_rendering:
@@ -307,7 +307,7 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
         hidden_objs = {ob.name for ob in bpy.context.view_layer.objects if not ob.visible_get() and ob.data is not None}
 
         self.last_used_textures.clear()
-        match depsgraph.scene.gameEditorMode:  # game mode implmentations
+        match depsgraph.scene.gameEditorMode:  # game mode implementations
             case "SM64":
                 draw_sm64_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
             case "OOT":

--- a/shader/defines.glsl
+++ b/shader/defines.glsl
@@ -142,18 +142,12 @@
 #define G_AD_DISABLE          (3 << G_MDSFT_ALPHADITHER)
 
 // Draw flags (custom for the shader)
-#define DRAW_FLAG_TEX0_MONO    (1 << 1)
-#define DRAW_FLAG_TEX1_MONO    (1 << 2)
-#define DRAW_FLAG_DECAL        (1 << 3)
-#define DRAW_FLAG_ALPHA_BLEND  (1 << 4) // temporary, @TODO: proper blending emulation
-#define DRAW_FLAG_TEX0_4BIT    (1 << 5)
-#define DRAW_FLAG_TEX1_4BIT    (1 << 6)
-#define DRAW_FLAG_TEX0_3BIT    (1 << 7)
-#define DRAW_FLAG_TEX1_3BIT    (1 << 8)
+#define DRAW_FLAG_DECAL        (1 << 0)
+#define DRAW_FLAG_ALPHA_BLEND  (1 << 1) // temporary, @TODO: proper blending emulation
 
-struct TileConf {
-  vec2 mask;
-  vec2 shift;
-  vec2 low;
-  vec2 high;
-};
+// Tex flags
+#define TEX_FLAG_MONO          (1 << 0)
+#define TEX_FLAG_4BIT          (1 << 1)
+#define TEX_FLAG_3BIT          (1 << 2)
+
+#define LOW_PRECISION          64

--- a/shader/main3d.frag.glsl
+++ b/shader/main3d.frag.glsl
@@ -3,6 +3,9 @@
   #extension GL_ARB_fragment_shader_interlock : enable
   layout(pixel_interlock_unordered) in;
 #endif
+#ifdef GL_ARB_derivative_control
+  #extension GL_ARB_derivative_control : enable
+#endif
 
 #define DECAL_DEPTH_DELTA 100
 
@@ -14,90 +17,153 @@ vec4 quantize4Bit(in vec4 color) {
   return round(color * 16.0) / 16.0; // (16 seems more accurate than 15)
 }
 
-vec4 quantizeTexture0(vec4 color) {
-  vec4 colorQuant = flagSelect(DRAW_FLAG_TEX0_4BIT, color, quantize4Bit(color));
-  return flagSelect(DRAW_FLAG_TEX0_3BIT, colorQuant, quantize3Bit(colorQuant));
+vec4 quantizeTexture(uint flags, vec4 color) {
+  vec4 colorQuant = flagSelect(flags, TEX_FLAG_4BIT, color, quantize4Bit(color));
+  colorQuant = flagSelect(flags, TEX_FLAG_3BIT, colorQuant, quantize3Bit(colorQuant));
+  colorQuant.rgb = linearToGamma(colorQuant.rgb);
+  return flagSelect(flags, TEX_FLAG_MONO, colorQuant.rgba, colorQuant.rrrr);
 }
 
-vec4 quantizeTexture1(vec4 color) {
-  vec4 colorQuant = flagSelect(DRAW_FLAG_TEX1_4BIT, color, quantize4Bit(color));
-  return flagSelect(DRAW_FLAG_TEX1_3BIT, colorQuant, quantize3Bit(colorQuant));
+vec4 sampleSampler(in const sampler2D tex, in const TileConf tileConf, in vec2 uvCoord, in const uint texFilter) {
+  // https://github.com/rt64/rt64/blob/61aa08f517cd16c1dbee4e097768b08e2a060307/src/shaders/TextureSampler.hlsli#L156-L276
+  const ivec2 texSize = textureSize(tex, 0);
+
+  uvCoord.y = texSize.y - uvCoord.y; // invert Y
+  uvCoord *= tileConf.shift;
+
+#ifdef SIMULATE_LOW_PRECISION
+  // Simulates the lower precision of the hardware's coordinate interpolation.
+  uvCoord = round(uvCoord * LOW_PRECISION) / LOW_PRECISION;
+#endif
+
+  uvCoord -= tileConf.low;
+
+  const vec2 isClamp      = step(tileConf.mask, vec2(1.0));
+  const vec2 isMirror     = step(tileConf.high, vec2(0.0));
+  const vec2 isForceClamp = step(tileConf.mask, vec2(1.0)); // mask == 0 forces clamping
+  const vec2 mask = mix(abs(tileConf.mask), vec2(256), isForceClamp); // if mask == 0, we also have to ignore it
+  const vec2 highMinusLow = abs(tileConf.high) - abs(tileConf.low);
+
+  if (texFilter != G_TF_POINT) {
+    uvCoord -= 0.5 * tileConf.shift;
+    const ivec2 texelBaseInt = ivec2(floor(uvCoord));
+    const vec4 sample00 = wrappedMirrorSample(tex, texelBaseInt,               mask, highMinusLow, isClamp, isMirror, isForceClamp);
+    const vec4 sample01 = wrappedMirrorSample(tex, texelBaseInt + ivec2(0, 1), mask, highMinusLow, isClamp, isMirror, isForceClamp);
+    const vec4 sample10 = wrappedMirrorSample(tex, texelBaseInt + ivec2(1, 0), mask, highMinusLow, isClamp, isMirror, isForceClamp);
+    const vec4 sample11 = wrappedMirrorSample(tex, texelBaseInt + ivec2(1, 1), mask, highMinusLow, isClamp, isMirror, isForceClamp);
+    const vec2 fracPart = uvCoord - texelBaseInt;
+#ifdef USE_LINEAR_FILTER
+    return quantizeTexture(tileConf.flags, mix(mix(sample00, sample10, fracPart.x), mix(sample01, sample11, fracPart.x), fracPart.y));
+#else
+    if (texFilter == G_TF_AVERAGE && all(lessThanEqual(vec2(1 / LOW_PRECISION), abs(fracPart - 0.5)))) {
+        return quantizeTexture(tileConf.flags, (sample00 + sample01 + sample10 + sample11) / 4.0f);
+    }
+    else {
+      // Originally written by ArthurCarvalho
+      // Sourced from https://www.emutalk.net/threads/emulating-nintendo-64-3-sample-bilinear-filtering-using-shaders.54215/
+      vec4 tri0 = mix(sample00, sample10, fracPart.x) + (sample01 - sample00) * fracPart.y;
+      vec4 tri1 = mix(sample11, sample01, 1.0 - fracPart.x) + (sample10 - sample11) * (1.0 - fracPart.y);
+      return quantizeTexture(tileConf.flags, mix(tri0, tri1, step(1.0, fracPart.x + fracPart.y)));
+    }
+#endif
+  }
+  else {
+    return quantizeTexture(tileConf.flags, wrappedMirrorSample(tex, ivec2(floor(uvCoord)), mask, highMinusLow, isClamp, isMirror, isForceClamp));
+  }
 }
 
-void fetchTex01Filtered(in ivec4 texSize, out vec4 texData0, out vec4 texData1)
-{
-  // Original 3-point code taken from: https://www.shadertoy.com/view/Ws2fWV (By: cyrb)
-  ivec4 uv0 = ivec4(floor(uv));
-  vec4 ratio = uv - vec4(uv0);
-
-  ivec2 lower_flag = ivec2(step(0.0, ratio.xz - ratio.yw));
-  ivec4 corner = ivec4(
-    lower_flag.x, 1 - lower_flag.x,
-    lower_flag.y, 1 - lower_flag.y
-  );
-
-  ivec4 uv1 = uv0 + corner;
-  ivec4 uv2 = uv0 + 1;
-
-  uv0 = wrappedMirror(texSize, uv0);
-  uv1 = wrappedMirror(texSize, uv1);
-  uv2 = wrappedMirror(texSize, uv2);
-
-  vec4 v0 = vec4(0 - corner);
-  vec4 v1 = vec4(1 - corner);
-  vec4 v2 = ratio - vec4(corner);
-
-  vec2 den = v0.xw * v1.yz - v1.xw * v0.yz;
-
-  vec2 lambda1 = abs((v2.xz * v1.yw - v1.xz * v2.yw) / den);
-  vec2 lambda2 = abs((v0.xz * v2.yw - v2.xz * v0.yw) / den);
-  vec2 lambda0 = 1.0 - lambda1 - lambda2;
-
-  texData0 =  quantizeTexture0(texelFetch(tex0, uv1.xy, 0)) * lambda0.x
-            + quantizeTexture0(texelFetch(tex0, uv0.xy, 0)) * lambda1.x
-            + quantizeTexture0(texelFetch(tex0, uv2.xy, 0)) * lambda2.x;
-  
-  texData1 =  quantizeTexture1(texelFetch(tex1, uv1.zw, 0)) * lambda0.y
-            + quantizeTexture1(texelFetch(tex1, uv0.zw, 0)) * lambda1.y
-            + quantizeTexture1(texelFetch(tex1, uv2.zw, 0)) * lambda2.y;
+vec4 sampleIndex(in const uint textureIndex, in const vec2 uvCoord, in const uint texFilter) {
+  TileConf tileConf = material.texConfs[textureIndex];
+  switch (textureIndex) {
+    default: return sampleSampler(tex0, tileConf, uvCoord, texFilter);
+    case 1: return sampleSampler(tex1, tileConf, uvCoord, texFilter);
+    case 2: return sampleSampler(tex2, tileConf, uvCoord, texFilter);
+    case 3: return sampleSampler(tex3, tileConf, uvCoord, texFilter);
+    case 4: return sampleSampler(tex4, tileConf, uvCoord, texFilter);
+    case 5: return sampleSampler(tex5, tileConf, uvCoord, texFilter);
+    case 6: return sampleSampler(tex6, tileConf, uvCoord, texFilter);
+    case 7: return sampleSampler(tex7, tileConf, uvCoord, texFilter);
+  }
 }
 
-vec3 cc_fetchColor(in int val, in vec4 shade, in vec4 comb, in vec4 texData0, in vec4 texData1)
+float computeLOD(inout uint tileIndex0, inout uint tileIndex1) {
+  // https://github.com/rt64/rt64/blob/0ca92eeb6c2f58ce3581c65f87f7261b8ac0fea0/src/shaders/TextureSampler.hlsli#L18
+  if (textLOD() == G_TL_TILE)
+    return 1.0f;
+  const uint texDetail = textDetail();
+  const bool lodSharpen = texDetail == G_TD_SHARPEN;
+  const bool lodDetail = texDetail == G_TD_DETAIL;
+  const bool lodSharpDetail = lodSharpen || lodDetail;
+
+#ifdef GL_ARB_derivative_control
+  const vec2 dfd = abs(vec2(dFdxCoarse(inputUV.x), dFdyCoarse(inputUV.y)));
+#else
+  const vec2 dfd = abs(vec2(dFdx(inputUV.x), dFdy(inputUV.y)));
+#endif
+  float maxDst = max(dfd.x, dfd.y);
+
+  if (lodSharpDetail) 
+    maxDst = max(maxDst, material.primLod.y);
+
+  int tileBase = int(floor(log2(maxDst)));
+  float lodFraction = maxDst / pow(2, max(tileBase, 0)) - 1.0;
+
+  if (lodSharpen && maxDst < 1.0)
+    lodFraction = maxDst - 1.0;
+
+  if (lodDetail) {
+    if (lodFraction < 0.0)
+      lodFraction = maxDst;
+    tileBase += 1;
+  } else if (tileBase >= material.mipCount)
+    lodFraction = 1.0;
+
+  if (lodSharpDetail) 
+    tileBase = max(tileBase, 0);
+  else 
+    lodFraction = max(lodFraction, 0.0);
+
+  tileIndex0 = clamp(tileBase, 0, material.mipCount);
+  tileIndex1 = clamp(tileBase + 1, 0, material.mipCount);
+  return lodFraction;
+}
+
+vec3 cc_fetchColor(in int val, in vec4 shade, in vec4 comb, in float lodFraction, in vec4 texData0, in vec4 texData1)
 {
        if(val == CC_C_COMB       ) return comb.rgb;
   else if(val == CC_C_TEX0       ) return texData0.rgb;
   else if(val == CC_C_TEX1       ) return texData1.rgb;
-  else if(val == CC_C_PRIM       ) return material.prim_color.rgb;
+  else if(val == CC_C_PRIM       ) return material.primColor.rgb;
   else if(val == CC_C_SHADE      ) return shade.rgb;
   else if(val == CC_C_ENV        ) return material.env.rgb;
-  else if(val == CC_C_CENTER     ) return material.ck_center.rgb;
-  else if(val == CC_C_SCALE      ) return material.ck_scale.rgb;
+  else if(val == CC_C_CENTER     ) return material.ckCenter.rgb;
+  else if(val == CC_C_SCALE      ) return material.ckScale;
   else if(val == CC_C_COMB_ALPHA ) return comb.aaa;
   else if(val == CC_C_TEX0_ALPHA ) return texData0.aaa;
   else if(val == CC_C_TEX1_ALPHA ) return texData1.aaa;
-  else if(val == CC_C_PRIM_ALPHA ) return material.prim_color.aaa;
+  else if(val == CC_C_PRIM_ALPHA ) return material.primColor.aaa;
   else if(val == CC_C_SHADE_ALPHA) return linearToGamma(shade.aaa);
   else if(val == CC_C_ENV_ALPHA  ) return material.env.aaa;
-  // else if(val == CC_C_LOD_FRAC   ) return vec3(0.0); // @TODO
-  else if(val == CC_C_PRIM_LOD_FRAC) return vec3(material.primLodDepth[1]);
+  else if(val == CC_C_LOD_FRAC   ) return vec3(lodFraction);
+  else if(val == CC_C_PRIM_LOD_FRAC) return vec3(material.primLod.x);
   else if(val == CC_C_NOISE      ) return vec3(noise(posScreen*0.25));
-  else if(val == CC_C_K4         ) return vec3(material.k_45[0]);
-  else if(val == CC_C_K5         ) return vec3(material.k_45[1]);
+  else if(val == CC_C_K4         ) return vec3(material.k45[0]);
+  else if(val == CC_C_K5         ) return vec3(material.k45[1]);
   else if(val == CC_C_1          ) return vec3(1.0);
   return vec3(0.0); // default: CC_C_0
 }
 
-float cc_fetchAlpha(in int val, vec4 shade, in vec4 comb, in vec4 texData0, in vec4 texData1)
+float cc_fetchAlpha(in int val, vec4 shade, in vec4 comb, in float lodFraction, in vec4 texData0, in vec4 texData1)
 {
-       if(val == CC_A_COMB ) return comb.a;
-  else if(val == CC_A_TEX0 ) return texData0.a;
-  else if(val == CC_A_TEX1 ) return texData1.a;
-  else if(val == CC_A_PRIM ) return material.prim_color.a;
-  else if(val == CC_A_SHADE) return shade.a;
-  else if(val == CC_A_ENV  ) return material.env.a;
-  // else if(val == CC_A_LOD_FRAC) return 0.0; // @TODO
-  else if(val == CC_A_PRIM_LOD_FRAC) return material.primLodDepth[1];
-  else if(val == CC_A_1    ) return 1.0;
+       if(val == CC_A_COMB )          return comb.a;
+  else if(val == CC_A_TEX0 )          return texData0.a;
+  else if(val == CC_A_TEX1 )          return texData1.a;
+  else if(val == CC_A_PRIM )          return material.primColor.a;
+  else if(val == CC_A_SHADE)          return shade.a;
+  else if(val == CC_A_ENV  )          return material.env.a;
+  else if(val == CC_A_LOD_FRAC)       return lodFraction;
+  else if(val == CC_A_PRIM_LOD_FRAC)  return material.primLod.x;
+  else if(val == CC_A_1    )          return 1.0;
   return 0.0; // default: CC_A_0
 }
 
@@ -116,7 +182,7 @@ vec4 cc_clampValue(in vec4 value)
   return clamp(value, 0.0, 1.0);
 }
 
-
+#ifdef BLEND_EMULATION
 vec4 blender_fetch(
   in int val, in vec4 colorBlend, in vec4 colorFog, in vec4 colorFB, in vec4 colorCC,
   in vec4 blenderA
@@ -166,13 +232,13 @@ bool color_depth_blending(
 {
   ivec2 screenPosPixel = ivec2(trunc(gl_FragCoord.xy));
   int oldDepth = imageAtomicMax(depth_texture, screenPosPixel, writeDepth);
-  int depthDiff = int(mixSelect(zSource() == G_ZS_PRIM, abs(oldDepth - currDepth), material.primLodDepth.w));
+  int depthDiff = int(mixSelect(zSource() == G_ZS_PRIM, abs(oldDepth - currDepth), material.primDepth.y));
 
   bool depthTest = currDepth >= oldDepth;
   if((DRAW_FLAGS & DRAW_FLAG_DECAL) != 0) {
     depthTest = depthDiff <= DECAL_DEPTH_DELTA;
   }
-    
+
   oldColorInt = imageLoad(color_texture, screenPosPixel).r;
   vec4 oldColor = unpackUnorm4x8(oldColorInt);
   oldColor.a = 0.0;
@@ -188,64 +254,49 @@ bool color_depth_blending(
   if(shouldDiscard)oldColorInt = writeColor;
   return shouldDiscard;
 }
+#endif
 
 void main()
 {
+  const uint cycleType = cycleType();
+  const uint texFilter = texFilter();
   vec4 cc0[4]; // inputs for 1. cycle
   vec4 cc1[4]; // inputs for 2. cycle
   vec4 ccValue = vec4(0.0); // result after 1/2 cycle
 
-  vec4 uvTex = uv;
-
   vec4 ccShade = geoModeSelect(G_SHADE_SMOOTH, cc_shade_flat, cc_shade);
 
-  // pre-calc UVs for both textures + get two extra points for 3-point sampling
-  // then sample both textures even if none are used. This is done to vectorize both
-  // the UV and clamp/mirror calculations, as well as minimize the number of texture fetches
-  vec4 texData0, texData1;
-  ivec4 texSize = ivec4(textureSize(tex0, 0), textureSize(tex1, 0)) - 1;
+  uint tex0Index = 0;
+  uint tex1Index = 1;
+  const float lodFraction = computeLOD(tex0Index, tex1Index);
 
-  if(texFilter() == G_TF_BILERP)
-  {
-    fetchTex01Filtered(texSize, texData0, texData1);
-  } else {
-    ivec4 uv0 = ivec4(floor(uv + 0.5));
-    uv0 = wrappedMirror(texSize, uv0);
-
-    texData0 = quantizeTexture0(texelFetch(tex0, uv0.xy, 0));
-    texData1 = quantizeTexture0(texelFetch(tex1, uv0.zw, 0));
-  }
-
-  // handle I4/I8
-  texData0.rgb = linearToGamma(texData0.rgb);
-  texData1.rgb = linearToGamma(texData1.rgb);
-  texData0.rgba = flagSelect(DRAW_FLAG_TEX0_MONO, texData0.rgba, texData0.rrrr);
-  texData1.rgba = flagSelect(DRAW_FLAG_TEX1_MONO, texData1.rgba, texData1.rrrr);
+  vec4 texData0 = sampleIndex(tex0Index, inputUV, texFilter);
+  vec4 texData1 = sampleIndex(tex1Index, inputUV, texFilter);
 
   // @TODO: emulate other formats, e.g. quantization?
 
-  cc0[0].rgb = cc_fetchColor(material.cc0Color.x, ccShade, ccValue, texData0, texData1);
-  cc0[1].rgb = cc_fetchColor(material.cc0Color.y, ccShade, ccValue, texData0, texData1);
-  cc0[2].rgb = cc_fetchColor(material.cc0Color.z, ccShade, ccValue, texData0, texData1);
-  cc0[3].rgb = cc_fetchColor(material.cc0Color.w, ccShade, ccValue, texData0, texData1);
+  cc0[0].rgb = cc_fetchColor(material.cc0Color.x, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[1].rgb = cc_fetchColor(material.cc0Color.y, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[2].rgb = cc_fetchColor(material.cc0Color.z, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[3].rgb = cc_fetchColor(material.cc0Color.w, ccShade, ccValue, lodFraction, texData0, texData1);
 
-  cc0[0].a = cc_fetchAlpha(material.cc0Alpha.x, ccShade, ccValue, texData0, texData1);
-  cc0[1].a = cc_fetchAlpha(material.cc0Alpha.y, ccShade, ccValue, texData0, texData1);
-  cc0[2].a = cc_fetchAlpha(material.cc0Alpha.z, ccShade, ccValue, texData0, texData1);
-  cc0[3].a = cc_fetchAlpha(material.cc0Alpha.w, ccShade, ccValue, texData0, texData1);
+  cc0[0].a = cc_fetchAlpha(material.cc0Alpha.x, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[1].a = cc_fetchAlpha(material.cc0Alpha.y, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[2].a = cc_fetchAlpha(material.cc0Alpha.z, ccShade, ccValue, lodFraction, texData0, texData1);
+  cc0[3].a = cc_fetchAlpha(material.cc0Alpha.w, ccShade, ccValue, lodFraction, texData0, texData1);
 
   ccValue = cc_overflowValue((cc0[0] - cc0[1]) * cc0[2] + cc0[3]);
 
-  if((OTHER_MODE_H & G_CYC_2CYCLE) != 0) {
-    cc1[0].rgb = cc_fetchColor(material.cc1Color.x, ccShade, ccValue, texData0, texData1);
-    cc1[1].rgb = cc_fetchColor(material.cc1Color.y, ccShade, ccValue, texData0, texData1);
-    cc1[2].rgb = cc_fetchColor(material.cc1Color.z, ccShade, ccValue, texData0, texData1);
-    cc1[3].rgb = cc_fetchColor(material.cc1Color.w, ccShade, ccValue, texData0, texData1);
+  if (cycleType == G_CYC_2CYCLE) {
+    cc1[0].rgb = cc_fetchColor(material.cc1Color.x, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[1].rgb = cc_fetchColor(material.cc1Color.y, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[2].rgb = cc_fetchColor(material.cc1Color.z, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[3].rgb = cc_fetchColor(material.cc1Color.w, ccShade, ccValue, lodFraction, texData0, texData1);
     
-    cc1[0].a = cc_fetchAlpha(material.cc1Alpha.x, ccShade, ccValue, texData0, texData1);
-    cc1[1].a = cc_fetchAlpha(material.cc1Alpha.y, ccShade, ccValue, texData0, texData1);
-    cc1[2].a = cc_fetchAlpha(material.cc1Alpha.z, ccShade, ccValue, texData0, texData1);
-    cc1[3].a = cc_fetchAlpha(material.cc1Alpha.w, ccShade, ccValue, texData0, texData1);
+    cc1[0].a = cc_fetchAlpha(material.cc1Alpha.x, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[1].a = cc_fetchAlpha(material.cc1Alpha.y, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[2].a = cc_fetchAlpha(material.cc1Alpha.z, ccShade, ccValue, lodFraction, texData0, texData1);
+    cc1[3].a = cc_fetchAlpha(material.cc1Alpha.w, ccShade, ccValue, lodFraction, texData0, texData1);
 
     ccValue = (cc1[0] - cc1[1]) * cc1[2] + cc1[3];
   }
@@ -253,6 +304,8 @@ void main()
   ccValue = cc_clampValue(cc_overflowValue(ccValue));
   ccValue.rgb = gammaToLinear(ccValue.rgb);
 
+  bool alphaTestFailed = ccValue.a < material.alphaClip;
+#ifdef BLEND_EMULATION
   // Depth / Decal handling:
   // We manually write & check depth values in an image in addition to the actual depth buffer.
   // This allows us to do manual compares (e.g. decals) and discard fragments based on that.
@@ -263,14 +316,13 @@ void main()
   // Note that this fallback can create small artifacts since depth and color are not able to be synchronized together.
   ivec2 screenPosPixel = ivec2(trunc(gl_FragCoord.xy));
 
-  int currDepth = int(mixSelect(zSource() == G_ZS_PRIM, gl_FragCoord.w * 0xFFFFF, material.primLodDepth.z));
-  int writeDepth = int(flagSelect(DRAW_FLAG_DECAL, currDepth, -0xFFFFFF));
+  int currDepth = int(mixSelect(zSource() == G_ZS_PRIM, gl_FragCoord.w * 0xFFFFF, material.primDepth.x));
+  int writeDepth = int(drawFlagSelect(DRAW_FLAG_DECAL, currDepth, -0xFFFFFF));
 
   if((DRAW_FLAGS & DRAW_FLAG_ALPHA_BLEND) != 0) {
     writeDepth = -0xFFFFFF;
   }
 
-  bool alphaTestFailed = ccValue.a < ALPHA_CLIP;
   if(alphaTestFailed)writeDepth = -0xFFFFFF;
 
   #ifdef USE_SHADER_INTERLOCK
@@ -308,4 +360,11 @@ void main()
   // but it will result in incoherent results (e.g. blocky artifacts due to depth related race-conditions)
   // This is most prominent on decals.
   discard;
+#else
+  if (alphaTestFailed) discard;
+  if((DRAW_FLAGS & DRAW_FLAG_ALPHA_BLEND) == 0) {
+    ccValue.a = 1.0;
+  }
+  FragColor = ccValue;
+#endif
 }

--- a/shader/main3d.vert.glsl
+++ b/shader/main3d.vert.glsl
@@ -5,12 +5,19 @@ void main()
   vec3 norm = inNormal;
   vec3 normScreen = normalize(matNorm * norm);
 
+#if VIEWSPACE_LIGHTING
+  vec3 light_norm = normScreen;
+#else 
+  vec3 light_norm = norm;
+#endif
+
   cc_shade = inColor;
 
   vec4 lightTotal = vec4(material.ambientColor.rgb, 0.0);
-  for(int i=0; i<2; ++i) {
-    float lightStren = max(dot(norm, material.lightDir[i].xyz), 0.0);
-    lightTotal += material.lightColor[i] * lightStren;
+  for(int i=0; i<material.numLights; i++) {
+    Light light = material.lights[i];
+    float lightStren = max(dot(light_norm, light.dir), 0.0);
+    lightTotal += light.color * lightStren;
   }
 
   lightTotal.rgb = clamp(lightTotal.rgb, 0.0, 1.0);
@@ -21,20 +28,9 @@ void main()
   cc_shade = clamp(cc_shade, 0.0, 1.0);
   cc_shade_flat = cc_shade;
 
-  vec2 uvGen = geoModeSelect(G_TEX_GEN, inUV, normScreen.xy * 0.5 + 0.5);
+  inputUV = geoModeSelect(G_TEX_GEN, inUV, normScreen.xy * 0.5 + 0.5);
 
-  // turn UVs ionto pixel-space, apply first tile settings
-  ivec4 texSize = ivec4(textureSize(tex0, 0), textureSize(tex1, 0));
-  // we simulate UVs in pixel-space, since there is only one UV set, we scale by the first texture size
-  uv = uvGen.xyxy * texSize.xyxy;
-  // apply material.shift from top left of texture:
-  uv.yw = texSize.yw - uv.yw - 1;
-  uv *= material.shift;
-  uv.yw = texSize.yw - uv.yw - 1;
-
-  uv = uv - (material.shift * 0.5) - material.low;
-
-  tileSize = abs(material.high) - abs(material.low);
+  inputUV *= material.texSize;
 
   // @TODO: uvgen (f3d + t3d)
   // forward CC (@TODO: do part of this here? e.g. prim/env/shade etc.)
@@ -49,6 +45,11 @@ void main()
   gl_Position.z = ceil(gl_Position.z * 0x7FFF) / 0x7FFF;
   // move the depth ever so slightly to avoid z-fighting with blenders own overlays
   // e.g. transparent faces in face-edit mode, lines & points
-  float depthOffset = flagSelect(DRAW_FLAG_DECAL, 0.00006, 0.0); // don't offset decals to make manual depth checks work later
-  gl_Position.z += depthOffset;
+
+#ifdef BLEND_EMULATION
+// don't offset decals to make manual depth checks work later
+  gl_Position.z += drawFlagSelect(DRAW_FLAG_DECAL, 0.00006, 0.0);
+#else
+  gl_Position.z = gl_Position.z * 1.00000018;
+#endif
 }

--- a/shader/structs.glsl
+++ b/shader/structs.glsl
@@ -1,14 +1,25 @@
 // NOTE: this file is included by blender via 'shader_info.typedef_source(...)'
 
+struct Light
+{
+  vec4 color;
+  vec3 dir;
+};
+
+struct TileConf
+{
+  vec2 mask;  // clamped if < 0, mask = abs(mask)
+  vec2 shift;
+  vec2 low;
+  vec2 high;  // if negative, mirrored, high = abs(high)
+  uint flags; // TODO: correct impl of this would be to process textures ahead of time, but this has to be done in fast64 first
+};
+
 struct UBO_Material
 {
+  TileConf texConfs[8]; // TODO: should these two be part of separate uniform buffers?
+  Light lights[8];
   ivec4 blender[2];
-
-  //Tile settings: xy = TEX0, zw = TEX1
-  vec4 mask; // clamped if < 0, mask = abs(mask)
-  vec4 shift;
-  vec4 low;
-  vec4 high; // if negative, mirrored, high = abs(high)
 
   // color-combiner
   ivec4 cc0Color;
@@ -17,20 +28,24 @@ struct UBO_Material
   ivec4 cc1Alpha;
 
   ivec4 modes; // geo, other-low, other-high, flags
-  vec4 lightColor[2];
-  vec4 lightDir[2]; // [0].w is alpha clip
-  vec4 prim_color;
+
+  vec4 primColor;
+  vec2 primLod; // x is frac, y is min
+  vec2 primDepth;
   vec4 env;
   vec4 ambientColor;
-  vec4 ck_center;
-  vec4 ck_scale;
-  vec4 primLodDepth;
-  vec4 k_0123;
-  vec2 k_45;  
+  vec3 ckCenter;
+  float alphaClip;
+  vec3 ckScale;
+  uint numLights;
+  vec3 ckWidth;
+  int mipCount;
+  vec4 k0123;
+  vec2 k45;
+  uvec2 texSize;
 };
 
 #define GEO_MODE     material.modes.x
 #define OTHER_MODE_L material.modes.y
 #define OTHER_MODE_H material.modes.z
 #define DRAW_FLAGS   material.modes.w
-#define ALPHA_CLIP   material.lightDir[0].w

--- a/shader/utils.glsl
+++ b/shader/utils.glsl
@@ -1,22 +1,33 @@
 #define GAMMA_FACTOR 2.2
 
-vec3 gammaToLinear(in vec3 color)
-{
-  return pow(color, vec3(GAMMA_FACTOR));
+vec3 gammaToLinear(in vec3 color) {
+  return mix(
+    color * (1.0 / 12.92),
+    pow((color + 0.055) * (1.0 / 1.055), vec3(2.4)),
+    step(0.04045, color)
+  );
 }
 
-vec3 linearToGamma(in vec3 color)
-{
-  return pow(color, vec3(1.0 / GAMMA_FACTOR));
+vec3 linearToGamma(in vec3 color) {
+  return mix(
+    color * 12.92,
+    1.055 * pow(color, vec3(1.0 / 2.4)) - 0.055,
+    step(0.0031308, color)
+  );
 }
 
 #define mixSelect(amount, a, b) (mix(a, b, float(amount)))
-#define flagSelect(flag_mask, a, b) (mixSelect((DRAW_FLAGS & flag_mask) != 0, a, b))
-#define geoModeSelect(flag_mask, a, b) (mixSelect((GEO_MODE & flag_mask) != 0, a, b))
-#define othermodeHSelect(flag_mask, a, b) mixSelect((material.othermodeH & flag_mask) != 0, a, b)
+#define flagSelect(flags, flag_mask, a, b) (mixSelect((flags & flag_mask) != 0, a, b))
+#define drawFlagSelect(flag_mask, a, b) flagSelect(DRAW_FLAGS, flag_mask, a, b)
+#define geoModeSelect(flag_mask, a, b) flagSelect(GEO_MODE, flag_mask, a, b)
+#define othermodeHSelect(flag_mask, a, b) flagSelect(material.othermodeH, flag_mask, a, b)
 
-#define zSource() (OTHER_MODE_L & (1 << G_MDSFT_ZSRCSEL))
-#define texFilter() (OTHER_MODE_H & (2 << G_MDSFT_TEXTFILT))
+#define zSource()   (OTHER_MODE_L & (1 << G_MDSFT_ZSRCSEL))
+#define cycleType() (OTHER_MODE_H & (3 << G_MDSFT_CYCLETYPE))
+#define texFilter() (OTHER_MODE_H & (3 << G_MDSFT_TEXTFILT))
+#define textPersp() (OTHER_MODE_H & (1 << G_MDSFT_TEXTPERSP))
+#define textLOD()   (OTHER_MODE_H & (1 << G_MDSFT_TEXTLOD))
+#define textDetail()(OTHER_MODE_H & (3 << G_MDSFT_TEXTDETAIL))
 
 #define boolSelect(cond, a, b) (bool(mix(a, b, cond)))
 
@@ -25,35 +36,28 @@ float noise(in vec2 uv)
   return fract(sin(dot(uv, vec2(12.9898, 78.233)))* 43758.5453);
 }
 
-vec4 mirrorUV(vec4 uvEnd, vec4 uvIn)
+vec2 mirrorUV(vec2 uvEnd, vec2 uvIn)
 {
-  vec4 uvMod2 = mod(uvIn, uvEnd * 2.0 + 1.0);
+  vec2 uvMod2 = mod(uvIn, uvEnd * 2.0 + 1.0);
   return mix(uvMod2, (uvEnd * 2.0) - uvMod2, step(uvEnd, uvMod2));
 }
 
-ivec4 wrappedMirror(ivec4 texSize, ivec4 uv)
+vec4 wrappedMirrorSample(const sampler2D tex, ivec2 uv, const vec2 mask, const vec2 highMinusLow,const  vec2 isClamp, const vec2 isMirror, const vec2 isForceClamp)
 {
-  vec4 mask = abs(material.mask);
+  const ivec2 texSize = textureSize(tex, 0);
 
-  // fetch settings
-  vec4 isClamp      = step(material.mask, vec4(1.0));
-  vec4 isMirror     = step(material.high, vec4(0.0));
-  vec4 isForceClamp = step(mask, vec4(1.0)); // mask == 0 forces clamping
-  mask = mix(mask, vec4(256), isForceClamp); // if mask == 0, we also have to ignore it
-
-  // @TODO: do this in vertex shader once initially
-  uv.yw = texSize.yw - uv.yw; // invert Y to have 0,0 in the top-left corner
-  
   // first apply clamping if enabled (clamp S/T, low S/T -> high S/T)
-  vec4 uvClamp = clamp(uv, vec4(0.0), tileSize);
-  uv = ivec4(mix(uv, uvClamp, isClamp));
+  const vec2 uvClamp = clamp(uv, vec2(0.0), highMinusLow);
+  uv = ivec2(mix(uv, uvClamp, isClamp));
 
   // then mirror the result if needed (mirror S/T)
-  vec4 uvMirror = mirrorUV(mask - vec4(0.5), vec4(uv));
-  uv = ivec4(mix(vec4(uv),  uvMirror, isMirror));
+  const vec2 uvMirror = mirrorUV(mask - vec2(0.5), vec2(uv));
+  uv = ivec2(mix(vec2(uv), uvMirror, isMirror));
   
   // clamp again (mask S/T), this is also done to avoid OOB texture access
-  uv = ivec4(mod(uv, min(texSize+1, mask)));
-  uv.yw = texSize.yw - uv.yw; // invert Y back
-  return uv;
+  uv = ivec2(mod(uv, min(texSize+1, mask)));
+
+  uv.y = texSize.y - uv.y - 1; // invert Y back
+
+  return texelFetch(tex, uv, 0);
 }

--- a/sm64.py
+++ b/sm64.py
@@ -1,0 +1,111 @@
+import copy
+from typing import NamedTuple
+
+import bpy
+import mathutils
+
+from .material.parser import parse_f3d_rendermode_preset, F64RenderState
+from .common import ObjRenderInfo, draw_f64_obj, collect_obj_info, get_scene_render_state
+from .properties import F64RenderSettings
+from .globals import F64_GLOBALS
+
+class AreaRenderInfo(NamedTuple): # areas, etc
+  render_state: F64RenderState
+  name: str
+  def __hash__(self):
+    return hash(self.name)
+
+def get_sm64_area_childrens(scene: bpy.types.Scene):
+  if F64_GLOBALS.sm64_area_lookup is not None:
+    return F64_GLOBALS.sm64_area_lookup
+
+  sm64_area_lookup = {}
+  render_state = get_scene_render_state(scene)
+  level_objs: list[bpy.types.Object] = []
+  area_objs: list[bpy.types.Object] = []
+
+  def get_area_children(obj: bpy.types.Object, name: str = ""):
+    for child in sorted(obj.children, key=lambda item: item.name): 
+      if child not in area_objs:
+        sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
+        get_area_children(child, name)
+      else:
+        get_area_children(child, child.name)
+
+  def get_level_children(obj: bpy.types.Object, name: str):
+    for child in sorted(obj.children, key=lambda item: item.name): 
+      if child in area_objs:
+        get_area_children(child, child.name)
+      else:
+        sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
+        get_level_children(child, name)
+
+  for obj in bpy.data.objects: # find all area type objects
+    if obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root": area_objs.append(obj)
+    if obj.type == "EMPTY":
+      if obj.sm64_obj_type == "Level Root": level_objs.append(obj)
+      if obj.sm64_obj_type == "Area Root": area_objs.append(obj)
+
+  for level_obj in level_objs:
+    get_level_children(level_obj, level_obj.name)
+
+  fake_area = AreaRenderInfo(render_state, "")
+  for obj in bpy.data.objects:
+    if obj.name not in sm64_area_lookup:
+      sm64_area_lookup[obj.name] = fake_area
+
+  F64_GLOBALS.sm64_area_lookup = sm64_area_lookup
+  return sm64_area_lookup
+
+# TODO if porting to fast64, reuse existing default layer dict
+DEFAULT_LAYERS = (("G_RM_ZB_OPA_SURF", "G_RM_ZB_OPA_SURF2"), 
+                      ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"), 
+                      ("G_RM_AA_ZB_OPA_DECAL", "G_RM_AA_ZB_OPA_DECAL2"), 
+                      ("G_RM_AA_ZB_OPA_INTER", "G_RM_AA_ZB_OPA_INTER2"), 
+                      ("G_RM_AA_ZB_TEX_EDGE", "G_RM_AA_ZB_TEX_EDGE2"), 
+                      ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"), 
+                      ("G_RM_AA_ZB_XLU_DECAL", "G_RM_AA_ZB_XLU_DECAL2"), 
+                      ("G_RM_AA_ZB_XLU_INTER", "G_RM_AA_ZB_XLU_INTER2"))
+
+def draw_sm64_scene(render_engine: "Fast64RenderEngine", depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool):
+  f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
+
+  layer_rendermodes = {} # TODO: should this be cached globally?
+  world = depsgraph.scene.world
+  for layer, (cycle1, cycle2) in enumerate(DEFAULT_LAYERS):
+    if world:
+      cycle1, cycle2 = (getattr(world, f"draw_layer_{layer}_cycle_{cycle}") for cycle in (1, 2))
+    rm_state = F64RenderState()
+    rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
+    rm_state.save_cache()
+    layer_rendermodes[layer] = rm_state
+
+  ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
+  specific_area = f64render_rs.sm64_specific_area.name if f64render_rs.sm64_specific_area else None
+  area_lookup = get_sm64_area_childrens(depsgraph.scene)
+  area_queue: dict[AreaRenderInfo, dict[int, dict[str, ObjRenderInfo]]] = {}
+
+  for obj in depsgraph.objects:
+    obj_name = obj.name
+    area = area_lookup[obj_name]
+    if (ignore and obj.ignore_render) or (collision and obj.ignore_collision) or (specific_area and area.name != specific_area):
+      continue
+    obj_info = collect_obj_info(render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set)
+    if obj_info is None:
+      continue
+  
+    layer_queue = area_queue.setdefault(area, {}) # if area has no queue, create it
+    for mat_info in obj_info.mats:
+      mat = mat_info[2]
+      obj_queue = layer_queue.setdefault(int(mat.layer or "0"), {}) # if layer has no queue, create it
+      if obj_name not in obj_queue: # if obj not already present in the layer's obj queue, create a shallow copy
+        obj_info = obj_queue[obj_name] = copy.copy(obj_info)
+        obj_info.mats = []
+      obj_queue[obj_name].mats.append(mat_info)
+
+  for area, layer_queue in area_queue.items():
+    render_state = area.render_state.copy()
+    for layer, obj_queue in sorted(layer_queue.items(), key=lambda item: item[0]): # sort by layer
+      render_state.set_values_from_cache(layer_rendermodes[layer])
+      for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])): # sort by obj name
+        draw_f64_obj(render_engine, render_state, obj_queue[info])

--- a/sm64.py
+++ b/sm64.py
@@ -9,103 +9,127 @@ from .common import ObjRenderInfo, draw_f64_obj, collect_obj_info, get_scene_ren
 from .properties import F64RenderSettings
 from .globals import F64_GLOBALS
 
-class AreaRenderInfo(NamedTuple): # areas, etc
-  render_state: F64RenderState
-  name: str
-  def __hash__(self):
-    return hash(self.name)
+
+class AreaRenderInfo(NamedTuple):  # areas, etc
+    render_state: F64RenderState
+    name: str
+
+    def __hash__(self):
+        return hash(self.name)
+
 
 def get_sm64_area_childrens(scene: bpy.types.Scene):
-  if F64_GLOBALS.sm64_area_lookup is not None:
-    return F64_GLOBALS.sm64_area_lookup
+    if F64_GLOBALS.sm64_area_lookup is not None:
+        return F64_GLOBALS.sm64_area_lookup
 
-  sm64_area_lookup = {}
-  render_state = get_scene_render_state(scene)
-  level_objs: list[bpy.types.Object] = []
-  area_objs: list[bpy.types.Object] = []
+    sm64_area_lookup = {}
+    render_state = get_scene_render_state(scene)
+    level_objs: list[bpy.types.Object] = []
+    area_objs: list[bpy.types.Object] = []
 
-  def get_area_children(obj: bpy.types.Object, name: str = ""):
-    for child in sorted(obj.children, key=lambda item: item.name): 
-      if child not in area_objs:
-        sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
-        get_area_children(child, name)
-      else:
-        get_area_children(child, child.name)
+    def get_area_children(obj: bpy.types.Object, name: str = ""):
+        for child in sorted(obj.children, key=lambda item: item.name):
+            if child not in area_objs:
+                sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
+                get_area_children(child, name)
+            else:
+                get_area_children(child, child.name)
 
-  def get_level_children(obj: bpy.types.Object, name: str):
-    for child in sorted(obj.children, key=lambda item: item.name): 
-      if child in area_objs:
-        get_area_children(child, child.name)
-      else:
-        sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
-        get_level_children(child, name)
+    def get_level_children(obj: bpy.types.Object, name: str):
+        for child in sorted(obj.children, key=lambda item: item.name):
+            if child in area_objs:
+                get_area_children(child, child.name)
+            else:
+                sm64_area_lookup[child.name] = AreaRenderInfo(render_state, name)
+                get_level_children(child, name)
 
-  for obj in bpy.data.objects: # find all area type objects
-    if obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root": area_objs.append(obj)
-    if obj.type == "EMPTY":
-      if obj.sm64_obj_type == "Level Root": level_objs.append(obj)
-      if obj.sm64_obj_type == "Area Root": area_objs.append(obj)
+    for obj in bpy.data.objects:  # find all area type objects
+        if obj.type == "EMPTY" and obj.sm64_obj_type == "Area Root":
+            area_objs.append(obj)
+        if obj.type == "EMPTY":
+            if obj.sm64_obj_type == "Level Root":
+                level_objs.append(obj)
+            if obj.sm64_obj_type == "Area Root":
+                area_objs.append(obj)
 
-  for level_obj in level_objs:
-    get_level_children(level_obj, level_obj.name)
+    for level_obj in level_objs:
+        get_level_children(level_obj, level_obj.name)
 
-  fake_area = AreaRenderInfo(render_state, "")
-  for obj in bpy.data.objects:
-    if obj.name not in sm64_area_lookup:
-      sm64_area_lookup[obj.name] = fake_area
+    fake_area = AreaRenderInfo(render_state, "")
+    for obj in bpy.data.objects:
+        if obj.name not in sm64_area_lookup:
+            sm64_area_lookup[obj.name] = fake_area
 
-  F64_GLOBALS.sm64_area_lookup = sm64_area_lookup
-  return sm64_area_lookup
+    F64_GLOBALS.sm64_area_lookup = sm64_area_lookup
+    return sm64_area_lookup
+
 
 # TODO if porting to fast64, reuse existing default layer dict
-DEFAULT_LAYERS = (("G_RM_ZB_OPA_SURF", "G_RM_ZB_OPA_SURF2"), 
-                      ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"), 
-                      ("G_RM_AA_ZB_OPA_DECAL", "G_RM_AA_ZB_OPA_DECAL2"), 
-                      ("G_RM_AA_ZB_OPA_INTER", "G_RM_AA_ZB_OPA_INTER2"), 
-                      ("G_RM_AA_ZB_TEX_EDGE", "G_RM_AA_ZB_TEX_EDGE2"), 
-                      ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"), 
-                      ("G_RM_AA_ZB_XLU_DECAL", "G_RM_AA_ZB_XLU_DECAL2"), 
-                      ("G_RM_AA_ZB_XLU_INTER", "G_RM_AA_ZB_XLU_INTER2"))
+DEFAULT_LAYERS = (
+    ("G_RM_ZB_OPA_SURF", "G_RM_ZB_OPA_SURF2"),
+    ("G_RM_AA_ZB_OPA_SURF", "G_RM_AA_ZB_OPA_SURF2"),
+    ("G_RM_AA_ZB_OPA_DECAL", "G_RM_AA_ZB_OPA_DECAL2"),
+    ("G_RM_AA_ZB_OPA_INTER", "G_RM_AA_ZB_OPA_INTER2"),
+    ("G_RM_AA_ZB_TEX_EDGE", "G_RM_AA_ZB_TEX_EDGE2"),
+    ("G_RM_AA_ZB_XLU_SURF", "G_RM_AA_ZB_XLU_SURF2"),
+    ("G_RM_AA_ZB_XLU_DECAL", "G_RM_AA_ZB_XLU_DECAL2"),
+    ("G_RM_AA_ZB_XLU_INTER", "G_RM_AA_ZB_XLU_INTER2"),
+)
 
-def draw_sm64_scene(render_engine: "Fast64RenderEngine", depsgraph: bpy.types.Depsgraph, hidden_objs_names: set[str], space_view_3d: bpy.types.SpaceView3D, projection_matrix: mathutils.Matrix, view_matrix: mathutils.Matrix, always_set: bool):
-  f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
 
-  layer_rendermodes = {} # TODO: should this be cached globally?
-  world = depsgraph.scene.world
-  for layer, (cycle1, cycle2) in enumerate(DEFAULT_LAYERS):
-    if world:
-      cycle1, cycle2 = (getattr(world, f"draw_layer_{layer}_cycle_{cycle}") for cycle in (1, 2))
-    rm_state = F64RenderState()
-    rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
-    rm_state.save_cache()
-    layer_rendermodes[layer] = rm_state
+def draw_sm64_scene(
+    render_engine: "Fast64RenderEngine",
+    depsgraph: bpy.types.Depsgraph,
+    hidden_objs_names: set[str],
+    space_view_3d: bpy.types.SpaceView3D,
+    projection_matrix: mathutils.Matrix,
+    view_matrix: mathutils.Matrix,
+    always_set: bool,
+):
+    f64render_rs: F64RenderSettings = depsgraph.scene.f64render.render_settings
 
-  ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
-  specific_area = f64render_rs.sm64_specific_area.name if f64render_rs.sm64_specific_area else None
-  area_lookup = get_sm64_area_childrens(depsgraph.scene)
-  area_queue: dict[AreaRenderInfo, dict[int, dict[str, ObjRenderInfo]]] = {}
+    layer_rendermodes = {}  # TODO: should this be cached globally?
+    world = depsgraph.scene.world
+    for layer, (cycle1, cycle2) in enumerate(DEFAULT_LAYERS):
+        if world:
+            cycle1, cycle2 = (getattr(world, f"draw_layer_{layer}_cycle_{cycle}") for cycle in (1, 2))
+        rm_state = F64RenderState()
+        rm_state.set_from_rendermode(parse_f3d_rendermode_preset(cycle1, cycle2))
+        rm_state.save_cache()
+        layer_rendermodes[layer] = rm_state
 
-  for obj in depsgraph.objects:
-    obj_name = obj.name
-    area = area_lookup[obj_name]
-    if (ignore and obj.ignore_render) or (collision and obj.ignore_collision) or (specific_area and area.name != specific_area):
-      continue
-    obj_info = collect_obj_info(render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set)
-    if obj_info is None:
-      continue
-  
-    layer_queue = area_queue.setdefault(area, {}) # if area has no queue, create it
-    for mat_info in obj_info.mats:
-      mat = mat_info[2]
-      obj_queue = layer_queue.setdefault(int(mat.layer or "0"), {}) # if layer has no queue, create it
-      if obj_name not in obj_queue: # if obj not already present in the layer's obj queue, create a shallow copy
-        obj_info = obj_queue[obj_name] = copy.copy(obj_info)
-        obj_info.mats = []
-      obj_queue[obj_name].mats.append(mat_info)
+    ignore, collision = f64render_rs.render_type == "IGNORE", f64render_rs.render_type == "COLLISION"
+    specific_area = f64render_rs.sm64_specific_area.name if f64render_rs.sm64_specific_area else None
+    area_lookup = get_sm64_area_childrens(depsgraph.scene)
+    area_queue: dict[AreaRenderInfo, dict[int, dict[str, ObjRenderInfo]]] = {}
 
-  for area, layer_queue in area_queue.items():
-    render_state = area.render_state.copy()
-    for layer, obj_queue in sorted(layer_queue.items(), key=lambda item: item[0]): # sort by layer
-      render_state.set_values_from_cache(layer_rendermodes[layer])
-      for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])): # sort by obj name
-        draw_f64_obj(render_engine, render_state, obj_queue[info])
+    for obj in depsgraph.objects:
+        obj_name = obj.name
+        area = area_lookup[obj_name]
+        if (
+            (ignore and obj.ignore_render)
+            or (collision and obj.ignore_collision)
+            or (specific_area and area.name != specific_area)
+        ):
+            continue
+        obj_info = collect_obj_info(
+            render_engine, obj, depsgraph, hidden_objs_names, space_view_3d, projection_matrix, view_matrix, always_set
+        )
+        if obj_info is None:
+            continue
+
+        layer_queue = area_queue.setdefault(area, {})  # if area has no queue, create it
+        for mat_info in obj_info.mats:
+            mat = mat_info[2]
+            obj_queue = layer_queue.setdefault(int(mat.layer or "0"), {})  # if layer has no queue, create it
+            if obj_name not in obj_queue:  # if obj not already present in the layer's obj queue, create a shallow copy
+                obj_info = obj_queue[obj_name] = copy.copy(obj_info)
+                obj_info.mats = []
+            obj_queue[obj_name].mats.append(mat_info)
+
+    for area, layer_queue in area_queue.items():
+        render_state = area.render_state.copy()
+        for layer, obj_queue in sorted(layer_queue.items(), key=lambda item: item[0]):  # sort by layer
+            render_state.set_values_from_cache(layer_rendermodes[layer])
+            for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])):  # sort by obj name
+                draw_f64_obj(render_engine, render_state, obj_queue[info])

--- a/utils/addon.py
+++ b/utils/addon.py
@@ -2,12 +2,13 @@ import sys
 import pathlib
 import addon_utils
 
+
 # Searches for fast64 and appends it to sys.path to allow importing functions
 def addon_set_fast64_path():
-  for mod in addon_utils.modules():
-    if mod.bl_info.get("name") == "Fast64":
-      f64_path = pathlib.Path(mod.__file__).parent
-      sys.path.append(str(f64_path))
-      return
-  
-  raise RuntimeError("Fast64 not found")
+    for mod in addon_utils.modules():
+        if mod.bl_info.get("name") == "Fast64":
+            f64_path = pathlib.Path(mod.__file__).parent
+            sys.path.append(str(f64_path))
+            return
+
+    raise RuntimeError("Fast64 not found")


### PR DESCRIPTION
it turns out this panel:

<img width="884" height="361" alt="image" src="https://github.com/user-attachments/assets/9c7c6c0b-92d8-4cb8-8ac6-086c9c023d7b" />

is eevee-specific so it is hidden by default for other renderers

But it's useful because it allows setting the light color which is used in at least oot and sm64

So this PR sets this panel to also show with the f64render renderer.

Note this causes a seemingly duplicate panel, as the other panel `DATA_PT_light` specific to non-EEVEE still shows

<img width="884" height="513" alt="image" src="https://github.com/user-attachments/assets/f76e8a6a-9e9b-4898-96eb-321a0d064e68" />

I could remove `DATA_PT_light` from the shown panels if we wanted but idk